### PR TITLE
fix: categorize gamification notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@
 - Remove unsupported fields from auth registration and welcome transaction.
 - Align gamification leaderboard and achievement data with defined types.
 - Guard optional marketplace product properties to avoid undefined access.
+- Categorize gamification notifications correctly to allow local builds.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ export default tseslint.config({
 
 - Global navigation now uses a single `MainLayout` from `app/layout.tsx`, ensuring the navbar is available throughout the site.
 - Various TypeScript errors were resolved and notification components were corrected for consistent behavior.
+- Gamification notifications are now categorized as `GAMIFICATION`, fixing local build errors.
+
+## Local Deployment
+
+To run the project locally:
+
+1. Install dependencies with `npm install`.
+2. Build the application using `npm run build`.
+3. Start the server with `npm start` or use `npm run dev` for development mode.
 
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 

--- a/src/services/gamificationService.ts
+++ b/src/services/gamificationService.ts
@@ -90,12 +90,12 @@ class GamificationService {
     notifications.push({
       id: `xp_${Date.now()}`,
       userId,
-      type: 'xp_gain',
+      type: 'GAMIFICATION',
       title: `¡+${amount} XP ganados!`,
       message: `Has ganado ${amount} XP por ${description}`,
       data: { amount, source, sourceId },
       read: false,
-      createdAt: new Date().toISOString()
+      createdAt: new Date()
     })
     
     // Enviar notificación usando el servicio
@@ -114,12 +114,12 @@ class GamificationService {
       notifications.push({
         id: `level_${Date.now()}`,
         userId,
-        type: 'level_up',
+        type: 'GAMIFICATION',
         title: '¡Subiste de Nivel!',
         message: `¡Felicidades! Ahora eres ${newLevel.name} (Nivel ${newLevel.level})`,
         data: { newLevel, rewards: newLevel.rewards },
         read: false,
-        createdAt: new Date().toISOString()
+        createdAt: new Date()
       })
       
       // Otorgar badges de nivel si los hay
@@ -130,12 +130,12 @@ class GamificationService {
             notifications.push({
               id: `badge_${Date.now()}_${badge.id}`,
               userId,
-              type: 'badge_earned',
+              type: 'GAMIFICATION',
               title: '¡Nueva Insignia!',
               message: `Has desbloqueado la insignia: ${badge.name}`,
               data: { badge },
               read: false,
-              createdAt: new Date().toISOString()
+              createdAt: new Date()
             })
           }
         }
@@ -299,12 +299,12 @@ class GamificationService {
         notifications.push({
           id: `streak_${Date.now()}`,
           userId,
-          type: 'streak_milestone',
+          type: 'GAMIFICATION',
           title: '¡Racha Semanal!',
           message: `¡Increíble! Has mantenido una racha de ${user.streak.current} días`,
           data: { streak: user.streak.current },
           read: false,
-          createdAt: new Date().toISOString()
+          createdAt: new Date()
         })
       }
     } else {


### PR DESCRIPTION
## Summary
- categorize gamification notifications as `GAMIFICATION`
- document local deployment steps
- update changelog

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_68acb4aa60d88321b32f744ccd911586