### PR TITLE
feat: add feed page and fix footer links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,6 @@
 - Align gamification leaderboard and achievement data with defined types.
 - Guard optional marketplace product properties to avoid undefined access.
 - Categorize gamification notifications correctly to allow local builds.
+- Add Feed page and navigation link in sidebar.
+- Correct footer links for Cookies, Privacy, Terms, and Support pages.
 

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,0 +1,32 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { Feed } from '@/components/feed/Feed';
+import { QuickActions } from '@/components/feed/QuickActions';
+import WeeklyStreak from '@/components/gamification/WeeklyStreak';
+import { TrendingTopics } from '@/components/feed/TrendingTopics';
+import { Suggestions } from '@/components/feed/Suggestions';
+
+export default async function FeedPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    redirect('/auth/login');
+  }
+
+  return (
+    [
+      <div key="left" className="space-y-6">
+        <QuickActions />
+        <WeeklyStreak />
+        <TrendingTopics />
+      </div>,
+      <div key="main" className="space-y-6">
+        <Feed />
+      </div>,
+      <div key="right" className="space-y-6">
+        <Suggestions />
+      </div>
+    ]
+  );
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -22,20 +22,20 @@ export function Footer() {
               >
                 Sobre
               </Link>
-              <Link 
-                href="/legal/cookies" 
+              <Link
+                href="/cookies"
                 className="text-gray-600 hover:text-crunevo-600 transition-colors"
               >
                 Cookies
               </Link>
-              <Link 
-                href="/legal/privacy" 
+              <Link
+                href="/privacy"
                 className="text-gray-600 hover:text-crunevo-600 transition-colors"
               >
                 Privacidad
               </Link>
-              <Link 
-                href="/legal/terms" 
+              <Link
+                href="/terms"
                 className="text-gray-600 hover:text-crunevo-600 transition-colors"
               >
                 Términos
@@ -52,8 +52,8 @@ export function Footer() {
               <div className="flex items-center space-x-4">
                 <span>Versión 1.0.0</span>
                 <span>•</span>
-                <Link 
-                  href="/support" 
+                <Link
+                  href="/help"
                   className="hover:text-crunevo-600 transition-colors"
                 >
                   Soporte

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -30,7 +30,8 @@ import {
   Grid3X3,
   GraduationCap,
   ShoppingBag,
-  Zap
+  Zap,
+  Rss
 } from 'lucide-react'
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -46,6 +47,7 @@ interface SidebarItem {
 
 const mainNavItems: SidebarItem[] = [
   { name: 'Inicio', href: '/', icon: Home },
+  { name: 'Feed', href: '/feed', icon: Rss },
   { name: 'Perfil', href: '/personal', icon: User },
   { name: 'Espacio Personal', href: '/personal', icon: Grid3X3, color: 'text-crunevo-600' },
   { name: 'Apuntes', href: '/notes', icon: FileText },


### PR DESCRIPTION
## Summary
- add feed page and navigation link in sidebar
- fix footer links for cookies, privacy, terms and support

## Testing
- `npm test` (fails: Missing script: "test")
- `npx eslint .`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68aeb38cd0f48321a413d74f8e76240d