### PR TITLE
feat: allow feed access without login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,5 @@
 - Categorize gamification notifications correctly to allow local builds.
 - Add Feed page and navigation link in sidebar.
 - Correct footer links for Cookies, Privacy, Terms, and Support pages.
+- Temporarily allow accessing the feed without authentication.
 

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,19 +1,11 @@
-import { redirect } from 'next/navigation';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { Feed } from '@/components/feed/Feed';
 import { QuickActions } from '@/components/feed/QuickActions';
 import WeeklyStreak from '@/components/gamification/WeeklyStreak';
 import { TrendingTopics } from '@/components/feed/TrendingTopics';
 import { Suggestions } from '@/components/feed/Suggestions';
 
-export default async function FeedPage() {
-  const session = await getServerSession(authOptions);
-
-  if (!session) {
-    redirect('/auth/login');
-  }
-
+export default function FeedPage() {
+  // Temporarily allow access without requiring authentication
   return (
     [
       <div key="left" className="space-y-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,19 +1,11 @@
-import { redirect } from 'next/navigation';
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { Feed } from '@/components/feed/Feed';
 import { QuickActions } from '@/components/feed/QuickActions';
 import WeeklyStreak from '@/components/gamification/WeeklyStreak';
 import { TrendingTopics } from '@/components/feed/TrendingTopics';
 import { Suggestions } from '@/components/feed/Suggestions';
 
-export default async function HomePage() {
-  const session = await getServerSession(authOptions);
-
-  if (!session) {
-    redirect('/auth/login');
-  }
-
+export default function HomePage() {
+  // Temporarily disable authentication requirement
   return (
     [
       /* Left Sidebar Content */


### PR DESCRIPTION
## Summary
- allow feed and home pages to render without requiring login
- note temporary public access in changelog

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68aeb95b0c9c8321b28d123d5ec394ac