### PR TITLE
fix: handle unauthenticated sessions gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,6 @@
 - Correct footer links for Cookies, Privacy, Terms, and Support pages.
 - Allow unauthenticated users to view public posts via the feed API.
 - Resolve feed API route type mismatches and enum casing errors.
+- Skip notification stream setup when unauthenticated to eliminate 401 errors.
+- Gracefully return an empty feed when the database is unavailable.
 

--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -168,10 +168,8 @@ export async function GET(request: NextRequest) {
     return NextResponse.json(response);
   } catch (error) {
     console.error('Feed GET error:', error);
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    const empty: FeedResponse = { posts: [], nextCursor: undefined, hasMore: false };
+    return NextResponse.json(empty, { status: 200 });
   }
 }
 

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
 import { Navbar } from './Navbar';
 import { Sidebar } from './Sidebar';
 import { Footer } from './Footer';
@@ -13,18 +14,22 @@ interface MainLayoutProps {
 }
 
 export function MainLayout({ children }: MainLayoutProps) {
+  const { status } = useSession();
+
   useEffect(() => {
-    // Initialize notification service
+    if (status !== 'authenticated') return;
+
+    // Initialize notification service only when authenticated
     notificationService.connect();
 
     // Request notification permissions
     notificationService.requestNotificationPermission();
-    
-    // Cleanup on unmount
+
+    // Cleanup on unmount or when session changes
     return () => {
       notificationService.disconnect();
     };
-  }, []);
+  }, [status]);
   
   return (
     <div className="min-h-screen bg-crunevo-gradient">


### PR DESCRIPTION
## Summary
- connect to notification stream only when user is authenticated
- return empty feed when backend errors occur

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run check` *(fails: cannot find generated page modules)*

------
https://chatgpt.com/codex/tasks/task_e_68af7fb9eeb08321a5593e6991d38641