### PR TITLE
feat: avoid unauthorized notifications for guests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,4 +12,5 @@
 - Correct footer links for Cookies, Privacy, Terms, and Support pages.
 - Allow unauthenticated users to view public posts via the feed API.
 - Resolve feed API route type mismatches and enum casing errors.
+- Avoid unauthorized errors by connecting the notification service only when the user is authenticated and handling 401 responses gracefully.
 

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
 import { Navbar } from './Navbar';
 import { Sidebar } from './Sidebar';
 import { Footer } from './Footer';
@@ -13,18 +14,22 @@ interface MainLayoutProps {
 }
 
 export function MainLayout({ children }: MainLayoutProps) {
+  const { data: session } = useSession();
+
   useEffect(() => {
-    // Initialize notification service
+    if (!session) return;
+
+    // Initialize notification service only for authenticated users
     notificationService.connect();
 
     // Request notification permissions
     notificationService.requestNotificationPermission();
-    
-    // Cleanup on unmount
+
+    // Cleanup on unmount or when session changes
     return () => {
       notificationService.disconnect();
     };
-  }, []);
+  }, [session]);
   
   return (
     <div className="min-h-screen bg-crunevo-gradient">

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -79,6 +79,12 @@ class NotificationService {
   private async loadNotifications() {
     try {
       const response = await fetch('/api/notifications');
+      if (response.status === 401) {
+        // Usuario no autenticado, sin notificaciones
+        this.notifications = [];
+        return;
+      }
+
       if (response.ok) {
         const data = await response.json();
         this.notifications = data.notifications.map((n: any) => ({


### PR DESCRIPTION
## Summary
- initialize notifications only for authenticated sessions
- handle guest access gracefully in notification service
- document notification service fix in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*


------
https://chatgpt.com/codex/tasks/task_e_68af7fb9eeb08321a5593e6991d38641