### PR TITLE
feat: add mock feed for local development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@
 - Resolve feed API route type mismatches and enum casing errors.
 - Skip notification stream setup when unauthenticated to eliminate 401 errors.
 - Gracefully return an empty feed when the database is unavailable.
+- Show mock feed posts and composer in development when the feed service is offline.
 

--- a/src/components/feed/Composer.tsx
+++ b/src/components/feed/Composer.tsx
@@ -85,6 +85,11 @@ const VISIBILITY_OPTIONS = [
 
 export function Composer({ className }: ComposerProps) {
   const { data: session } = useSession();
+  const isDev = process.env.NODE_ENV !== 'production';
+  const user = session?.user ||
+    (isDev
+      ? { id: 'demo', name: 'Usuario Demo', image: 'https://placehold.co/100x100' }
+      : null);
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   
@@ -261,7 +266,7 @@ export function Composer({ className }: ComposerProps) {
     }
   };
 
-  if (!session) {
+  if (!user) {
     return (
       <Card className={cn('p-6 text-center', className)}>
         <p className="text-gray-600">Inicia sesión para crear publicaciones</p>
@@ -276,13 +281,13 @@ export function Composer({ className }: ComposerProps) {
         <div className="p-4 border-b border-gray-100">
           <div className="flex items-center space-x-3">
             <Avatar className="w-10 h-10 ring-2 ring-transparent hover:ring-orange-200 transition-all duration-300">
-              <AvatarImage src={session.user?.image || ''} alt={session.user?.name || ''} />
+              <AvatarImage src={user.image || ''} alt={user.name || ''} />
               <AvatarFallback className="bg-gradient-to-br from-orange-100 to-orange-200 text-orange-700">
-                {session.user?.name?.split(' ').map(n => n[0]).join('') || 'U'}
+                {user.name?.split(' ').map(n => n[0]).join('') || 'U'}
               </AvatarFallback>
             </Avatar>
             <div className="flex-1">
-              <p className="font-medium text-gray-900">{session.user?.name}</p>
+              <p className="font-medium text-gray-900">{user.name}</p>
               <p className="text-sm text-gray-500">¿Qué quieres compartir?</p>
             </div>
           </div>

--- a/src/components/feed/PostList.tsx
+++ b/src/components/feed/PostList.tsx
@@ -10,6 +10,7 @@ import { RefreshCw, Wifi, WifiOff } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { FeedPost, FeedResponse, FeedRanking } from '@/types/feed';
+import { mockFeedPosts } from './mockData';
 
 interface PostListProps {
   ranking?: FeedRanking;
@@ -30,6 +31,7 @@ export function PostList({
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const isIntersecting = useIntersection(loadMoreRef, { threshold: 0.1 });
+  const isDev = process.env.NODE_ENV !== 'production';
 
   // Build query key
   const queryKey = ['feed', ranking, authorId, hashtag].filter(Boolean);
@@ -183,6 +185,22 @@ export function PostList({
     );
   }
 
+  // Use mock posts in development when the query fails or returns empty
+  const fallbackPosts =
+    isDev && (isError || allPosts.length === 0) ? mockFeedPosts : null;
+
+  if (fallbackPosts) {
+    return (
+      <div className={cn('space-y-6', className)} ref={listRef}>
+        {fallbackPosts.map((post, index) => (
+          <div key={post.id} data-post-id={post.id}>
+            <PostCard post={post} priority={index < 3} />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   // Error state
   if (isError) {
     return (
@@ -206,7 +224,7 @@ export function PostList({
     );
   }
 
-  // Empty state
+  // Empty state (production only)
   if (allPosts.length === 0) {
     return (
       <div className={cn('text-center py-12', className)}>

--- a/src/components/feed/mockData.ts
+++ b/src/components/feed/mockData.ts
@@ -1,0 +1,59 @@
+import { FeedPost } from '@/types/feed';
+
+// Mock posts used in development when the feed service is unavailable
+export const mockFeedPosts: FeedPost[] = [
+  {
+    id: '1',
+    kind: 'question',
+    author: {
+      id: '1',
+      name: 'María González',
+      username: 'maria_g',
+      avatar: 'https://placehold.co/100x100',
+      verified: true,
+    },
+    createdAt: new Date().toISOString(),
+    title: '¿Cómo optimizar algoritmos de ordenamiento?',
+    text: 'Estoy estudiando diferentes algoritmos de ordenamiento y me gustaría saber cuáles son las mejores prácticas para optimizarlos. ¿Alguien tiene experiencia con QuickSort vs MergeSort?',
+    visibility: 'public',
+    hashtags: ['algoritmos', 'programacion', 'optimizacion'],
+    stats: { fires: 24, comments: 8, shares: 3, saves: 5, views: 120 },
+    viewerState: { fired: false, saved: true, shared: false },
+  },
+  {
+    id: '2',
+    kind: 'note',
+    author: {
+      id: '2',
+      name: 'Carlos Mendoza',
+      username: 'carlos_m',
+      avatar: 'https://placehold.co/100x100',
+      verified: false,
+    },
+    createdAt: new Date().toISOString(),
+    title: 'Apuntes de Anatomía - Sistema Cardiovascular',
+    text: 'Comparto mis apuntes completos sobre el sistema cardiovascular. Incluye diagramas, funciones principales y patologías más comunes.',
+    visibility: 'public',
+    hashtags: ['anatomia', 'medicina', 'cardiovascular'],
+    stats: { fires: 45, comments: 12, shares: 18, saves: 7, views: 300 },
+    viewerState: { fired: true, saved: false, shared: false },
+  },
+  {
+    id: '3',
+    kind: 'post',
+    author: {
+      id: '3',
+      name: 'Ana Rodríguez',
+      username: 'ana_r',
+      avatar: 'https://placehold.co/100x100',
+      verified: true,
+    },
+    createdAt: new Date().toISOString(),
+    text: '¡Acabo de terminar mi tesis sobre neuroplasticidad! Ha sido un viaje increíble de 2 años. Gracias a todos los que me apoyaron en el proceso. 🧠✨',
+    visibility: 'public',
+    hashtags: ['tesis', 'neuroplasticidad', 'psicologia'],
+    stats: { fires: 89, comments: 23, shares: 7, saves: 15, views: 500 },
+    viewerState: { fired: true, saved: true, shared: false },
+  },
+];
+


### PR DESCRIPTION
## Summary
- show demo posts when feed API fails or returns empty in development
- allow Composer to render with a mock user locally
- document local feed behaviour

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for configuration)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68af906a52b083218c1214e08e057196