### PR TITLE
Add feed route and router links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,5 @@
 - Gracefully return an empty feed when the database is unavailable.
 - Show mock feed posts and composer in development when the feed service is offline.
 - Render home page content instead of a blank screen and replace Next.js links with React Router links.
+- Fix missing Feed route and update feed component links to use React Router so the social network is displayed correctly.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,13 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "@/pages/Home";
+import Feed from "@/components/feed/Feed";
 
 export default function App() {
   return (
     <Router>
       <Routes>
         <Route path="/" element={<Home />} />
+        <Route path="/feed" element={<Feed />} />
         <Route path="/other" element={<div className="text-center text-xl">Other Page - Coming Soon</div>} />
       </Routes>
     </Router>

--- a/src/components/feed/Feed.tsx
+++ b/src/components/feed/Feed.tsx
@@ -15,7 +15,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
-import Link from 'next/link';
+import { Link } from 'react-router-dom';
 import { CreatePost } from './CreatePost';
 import { gamificationService } from '@/services/gamificationService';
 
@@ -297,7 +297,7 @@ export function Feed() {
           Sigue a otros usuarios, únete a clubes o crea tu primera publicación.
         </p>
         <Button asChild>
-          <Link href="/create-post">
+          <Link to="/create-post">
             Crear primera publicación
           </Link>
         </Button>
@@ -337,8 +337,8 @@ export function Feed() {
                 
                 <div>
                   <div className="flex items-center space-x-2">
-                    <Link 
-                      href={`/profile/${post.author.username}`}
+                    <Link
+                      to={`/profile/${post.author.username}`}
                       className="font-semibold text-gray-900 hover:text-crunevo-600 transition-all duration-200 hover:scale-105 inline-block"
                     >
                       {post.author.name}
@@ -457,7 +457,7 @@ export function Feed() {
             {post.tags.length > 0 && (
               <div className="flex flex-wrap gap-2 mb-4">
                 {post.tags.map((tag) => (
-                  <Link key={tag} href={`/search?q=${encodeURIComponent(tag)}`}>
+                  <Link key={tag} to={`/search?q=${encodeURIComponent(tag)}`}>
                     <Badge 
                       variant="secondary" 
                       className="text-xs hover:bg-crunevo-100 hover:text-crunevo-700 transition-colors cursor-pointer"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { SessionProvider } from "next-auth/react";
 import App from "./App";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <SessionProvider>
+      <App />
+    </SessionProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- expose feed at `/feed`
- replace Next.js links with React Router links in feed component
- wrap app with `SessionProvider` to prevent session errors

## Testing
- `npm run check`
- `npm run lint` *(fails: prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68afd91b64a88321871ece4c1a26ddaf