### PR TITLE
feat(auth): stub session endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,5 @@
 - Show mock feed posts and composer in development when the feed service is offline.
 - Render home page content instead of a blank screen and replace Next.js links with React Router links.
 - Fix missing Feed route and update feed component links to use React Router so the social network is displayed correctly.
+- Stub authentication routes and add a session endpoint to avoid 404 errors during development.
 

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -13,6 +13,7 @@ const router = Router();
  */
 router.post('/register', async (req: Request, res: Response): Promise<void> => {
   // TODO: Implement register logic
+  res.status(501).json({ success: false, error: 'Not implemented' });
 });
 
 /**
@@ -21,6 +22,7 @@ router.post('/register', async (req: Request, res: Response): Promise<void> => {
  */
 router.post('/login', async (req: Request, res: Response): Promise<void> => {
   // TODO: Implement login logic
+  res.status(501).json({ success: false, error: 'Not implemented' });
 });
 
 /**
@@ -29,6 +31,16 @@ router.post('/login', async (req: Request, res: Response): Promise<void> => {
  */
 router.post('/logout', async (req: Request, res: Response): Promise<void> => {
   // TODO: Implement logout logic
+  res.status(501).json({ success: false, error: 'Not implemented' });
+});
+
+/**
+ * Get current session
+ * GET /api/auth/session
+ */
+router.get('/session', async (req: Request, res: Response): Promise<void> => {
+  // Return null session until auth is implemented
+  res.status(200).json(null);
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- stub auth routes with placeholder responses
- add `/api/auth/session` endpoint to return null session
- document stubbed routes in changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run check`
- `PORT=3003 npx tsx api/server.ts` (manual)
- `curl -s http://localhost:3003/api/auth/session`

------
https://chatgpt.com/codex/tasks/task_e_68afddd7c914832183ab538a4d72d4ca