### PR TITLE
fix: correct Feed import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix TypeScript build errors across project.
+- Correct Feed import in App.tsx to use named export.
 - Move notification stream helpers to `src/lib/notificationStream.ts`.
 - Remove unsupported fields from auth registration and welcome transaction.
 - Align gamification leaderboard and achievement data with defined types.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "@/pages/Home";
-import Feed from "@/components/feed/Feed";
+import { Feed } from "@/components/feed/Feed";
 
 export default function App() {
   return (


### PR DESCRIPTION
## Summary
- fix Feed import to use named export
- document Feed import fix in changelog

## Testing
- `npm run check` *(fails: Cannot find module '../../../../app/gamification/page.js' or its corresponding type declarations, and other Prisma-related TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68afe1e9b8e48321bb3187f4d3c46f2b