### PR TITLE
Rename Espacio Personal to Workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,4 +19,5 @@
 - Render home page content instead of a blank screen and replace Next.js links with React Router links.
 - Fix missing Feed route and update feed component links to use React Router so the social network is displayed correctly.
 - Stub authentication routes and add a session endpoint to avoid 404 errors during development.
+- Rename "Espacio Personal" navigation item to "Workspace" and fix related links.
 

--- a/idea.md
+++ b/idea.md
@@ -299,7 +299,7 @@
   * `/profile/:username` (vista pÃºblica) y `/me` (vista privada)
   * `/settings` (tabs: perfil, tienda, verificaciÃ³n, notifs, tema, legal)
   * `/notifications`
-  * `/personal-space`
+  * `/workspace`
   * `/crunebot` (desactivado)
   * `/plus` (Crunevo+)
 

--- a/src/components/layout/FloatingActionButton.tsx
+++ b/src/components/layout/FloatingActionButton.tsx
@@ -18,10 +18,10 @@ interface QuickAction {
 const quickActions: QuickAction[] = [
   {
     name: 'Nota Rápida',
-    href: '/personal-space?action=quick-note',
+    href: '/workspace?action=quick-note',
     icon: FileText,
     color: 'bg-blue-500 hover:bg-blue-600',
-    description: 'Crear una nota rápida en tu espacio personal'
+    description: 'Crear una nota rápida en tu workspace'
   },
   {
     name: 'Pregunta',

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -108,9 +108,9 @@ export function Navbar() {
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>
-                  <Link href="/personal-space" className="flex items-center">
+                  <Link href="/workspace" className="flex items-center">
                     <div className="mr-2 h-4 w-4 bg-crunevo-500 rounded-sm"></div>
-                    <span>Espacio Personal</span>
+                    <span>Workspace</span>
                   </Link>
                 </DropdownMenuItem>
                 <DropdownMenuItem asChild>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -49,7 +49,7 @@ const mainNavItems: SidebarItem[] = [
   { name: 'Inicio', href: '/', icon: Home },
   { name: 'Feed', href: '/feed', icon: Rss },
   { name: 'Perfil', href: '/perfil', icon: User },
-  { name: 'Espacio Personal', href: '/workspace', icon: Grid3X3, color: 'text-crunevo-600' },
+  { name: 'Workspace', href: '/workspace', icon: Grid3X3, color: 'text-crunevo-600' },
   { name: 'Apuntes', href: '/notes', icon: FileText },
   { name: 'Foro', href: '/forum', icon: MessageSquare },
   { name: 'Clubes', href: '/clubs', icon: Users },


### PR DESCRIPTION
## Summary
- Rename navigation label from "Espacio Personal" to "Workspace"
- Fix related links and quick action description to use `/workspace`
- Update documentation and changelog

## Testing
- `npx eslint .` *(fails: 1008 problems)*
- `npm run check` *(fails: property 'kanbanCard' does not exist on type 'PrismaClient')*


------
https://chatgpt.com/codex/tasks/task_e_68affcb683e0832191cc234ec83c98f4