### PR TITLE
Simplify dev setup for Next.js and configure database path

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,4 @@
 NEXTAUTH_URL=http://localhost:3000
 AUTH_TRUST_HOST=true
 NEXTAUTH_SECRET=super-long-secret-value-1234567890abcdef
-DATABASE_URL="file:./prisma/dev.db"
+DATABASE_URL="file:/workspace/PRUEBA/prisma/dev.db"

--- a/package.json
+++ b/package.json
@@ -4,12 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "concurrently \"npm run client:dev\" \"npm run server:dev\"",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start -H 0.0.0.0 -p 8080",
-    "lint": "next lint",
-    "client:dev": "next dev",
-    "server:dev": "nodemon"
+    "lint": "next lint"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^2.10.0",


### PR DESCRIPTION
## Summary
- Streamline development by running Next.js with a single `next dev` script
- Point Prisma to the local SQLite database using an absolute path for reliability

## Testing
- `curl -s http://localhost:3000/api/health`
- `curl -s -b cookies.txt http://localhost:3000/api/auth/session`
- `curl -s -b cookies.txt http://localhost:3000/api/workspace/debug`
- `curl -s -b cookies.txt http://localhost:3000/api/workspace/boards`
- `curl -s -b cookies.txt -X POST http://localhost:3000/api/workspace/blocks -H "Content-Type: application/json" -d '{"boardId":"cmew9zqsd0001lp261qzoopwv","type":"DOCS","title":"Doc Inicial","w":300,"h":200,"x":20,"y":20}'`
- `curl -s -b cookies.txt "http://localhost:3000/api/workspace/boards/cmew9zqsd0001lp261qzoopwv/blocks"`


------
https://chatgpt.com/codex/tasks/task_e_68b11c4ab8888321a086c9620843ab61