### PR TITLE
fix workspace session provider and dev env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,4 +21,5 @@
 - Stub authentication routes and add a session endpoint to avoid 404 errors during development.
 - Rename "Espacio Personal" navigation item to "Workspace" and fix related links.
 - Wrap root layout with SessionProvider and improve workspace board loading to prevent endless "Cargando..." state.
+- Move SessionProvider into client Providers and add development session fallback so workspace loads without RSC errors.
 

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,0 +1,40 @@
+# Desarrollo local
+
+## Variables de entorno necesarias
+
+Crea un archivo `.env.local` con:
+
+```
+NEXTAUTH_URL=http://localhost:3000
+AUTH_TRUST_HOST=true
+NEXTAUTH_SECRET=some-long-random-string
+DATABASE_URL="file:./prisma/dev.db"
+```
+
+## Pasos
+
+1. Instalar dependencias:
+   ```bash
+   npm ci
+   ```
+2. Sincronizar base de datos:
+   ```bash
+   npx prisma db push
+   ```
+3. Poblar datos de ejemplo (opcional):
+   ```bash
+   npm run db:seed
+   ```
+4. Iniciar servidor de desarrollo:
+   ```bash
+   npm run dev
+   ```
+
+## Endpoints útiles
+
+- `GET /api/health`
+- `GET /api/auth/session`
+- `GET /api/workspace/debug`
+- `GET /api/workspace/boards`
+
+En desarrollo, si no hay sesión activa, las rutas de `workspace` utilizan el primer usuario de la base de datos como sesión simulada.

--- a/app/api/workspace/blocks/[id]/route.ts
+++ b/app/api/workspace/blocks/[id]/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const proxy = await proxyWorkspace(req, `/blocks/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -37,7 +36,7 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   const proxy = await proxyWorkspace(req, `/blocks/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/blocks/route.ts
+++ b/app/api/workspace/blocks/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(req: Request) {
   const proxy = await proxyWorkspace(req, '/blocks');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -40,7 +39,7 @@ export async function POST(req: Request) {
   const proxy = await proxyWorkspace(req, '/blocks');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/boards/[boardId]/blocks/route.ts
+++ b/app/api/workspace/boards/[boardId]/blocks/route.ts
@@ -2,10 +2,9 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(
   req: Request,
@@ -14,7 +13,7 @@ export async function GET(
   const proxy = await proxyWorkspace(req, `/boards/${params.boardId}/blocks`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/boards/route.ts
+++ b/app/api/workspace/boards/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(req: Request) {
   const proxy = await proxyWorkspace(req, '/boards');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -55,7 +54,7 @@ export async function POST(req: Request) {
   const proxy = await proxyWorkspace(req, '/boards');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/debug/route.ts
+++ b/app/api/workspace/debug/route.ts
@@ -2,15 +2,14 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(req: Request) {
   const proxy = await proxyWorkspace(req, '/debug');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/docs/pages/[id]/route.ts
+++ b/app/api/workspace/docs/pages/[id]/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const proxy = await proxyWorkspace(req, `/docs/pages/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -34,7 +33,7 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   const proxy = await proxyWorkspace(req, `/docs/pages/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/docs/pages/route.ts
+++ b/app/api/workspace/docs/pages/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(req: Request) {
   const proxy = await proxyWorkspace(req, '/docs/pages');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -35,7 +34,7 @@ export async function POST(req: Request) {
   const proxy = await proxyWorkspace(req, '/docs/pages');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/frases/items/[id]/route.ts
+++ b/app/api/workspace/frases/items/[id]/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const proxy = await proxyWorkspace(req, `/frases/items/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -34,7 +33,7 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   const proxy = await proxyWorkspace(req, `/frases/items/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/frases/items/route.ts
+++ b/app/api/workspace/frases/items/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(req: Request) {
   const proxy = await proxyWorkspace(req, '/frases/items');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -35,7 +34,7 @@ export async function POST(req: Request) {
   const proxy = await proxyWorkspace(req, '/frases/items');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/kanban/cards/[id]/route.ts
+++ b/app/api/workspace/kanban/cards/[id]/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const proxy = await proxyWorkspace(req, `/kanban/cards/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -34,7 +33,7 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   const proxy = await proxyWorkspace(req, `/kanban/cards/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/kanban/cards/route.ts
+++ b/app/api/workspace/kanban/cards/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(req: Request) {
   const proxy = await proxyWorkspace(req, '/kanban/cards');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -35,7 +34,7 @@ export async function POST(req: Request) {
   const proxy = await proxyWorkspace(req, '/kanban/cards');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/kanban/columns/[id]/route.ts
+++ b/app/api/workspace/kanban/columns/[id]/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function PATCH(req: Request, { params }: { params: { id: string } }) {
   const proxy = await proxyWorkspace(req, `/kanban/columns/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -34,7 +33,7 @@ export async function DELETE(req: Request, { params }: { params: { id: string } 
   const proxy = await proxyWorkspace(req, `/kanban/columns/${params.id}`);
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/workspace/kanban/columns/route.ts
+++ b/app/api/workspace/kanban/columns/route.ts
@@ -2,16 +2,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
-import { getServerSession } from 'next-auth';
-import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { proxyWorkspace } from '@/lib/workspace-proxy';
+import { getSession } from '@/lib/session';
 
 export async function GET(req: Request) {
   const proxy = await proxyWorkspace(req, '/kanban/columns');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
@@ -36,7 +35,7 @@ export async function POST(req: Request) {
   const proxy = await proxyWorkspace(req, '/kanban/columns');
   if (proxy) return proxy;
   try {
-    const session = await getServerSession(authOptions);
+    const session = await getSession();
     if (!session?.user?.id) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
 import { MainLayout } from "../src/components/layout/MainLayout";
-import { SessionProvider } from "next-auth/react";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -29,13 +28,11 @@ export default function RootLayout({
   return (
     <html lang="es" className={inter.variable}>
       <body className="font-sans antialiased bg-gray-50">
-        <SessionProvider>
-          <Providers>
-            <MainLayout>
-              {children}
-            </MainLayout>
-          </Providers>
-        </SessionProvider>
+        <Providers>
+          <MainLayout>
+            {children}
+          </MainLayout>
+        </Providers>
       </body>
     </html>
   );

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { Toaster } from 'sonner'
 import { useState } from 'react'
+import { SessionProvider } from 'next-auth/react'
 
 interface ProvidersProps {
   children: React.ReactNode
@@ -27,23 +28,25 @@ export default function Providers({ children }: ProvidersProps) {
   )
 
   return (
-    <QueryClientProvider client={queryClient}>
-      {children}
-      <Toaster
-        position="top-right"
-        richColors
-        closeButton
-        duration={4000}
-        theme="light"
-        toastOptions={{
-          style: {
-            background: 'white',
-            border: '1px solid #e2e8f0',
-            color: '#1e293b',
-          },
-        }}
-      />
-      <ReactQueryDevtools initialIsOpen={false} />
-    </QueryClientProvider>
+    <SessionProvider>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <Toaster
+          position="top-right"
+          richColors
+          closeButton
+          duration={4000}
+          theme="light"
+          toastOptions={{
+            style: {
+              background: 'white',
+              border: '1px solid #e2e8f0',
+              color: '#1e293b',
+            },
+          }}
+        />
+        <ReactQueryDevtools initialIsOpen={false} />
+      </QueryClientProvider>
+    </SessionProvider>
   )
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -H 0.0.0.0 -p 8080",
+    "start": "next start -H 0.0.0.0 -p 3000",
+    "db:push": "prisma db push",
+    "db:seed": "tsx scripts/seed.ts",
     "lint": "next lint"
   },
   "dependencies": {

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,0 +1,22 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Wrapper around getServerSession with development fallback.
+ * If running in development and no session exists, it will
+ * return the first user as a mock session so workspace APIs
+ * can be tested without going through the login flow.
+ */
+export async function getSession() {
+  let session = await getServerSession(authOptions);
+  if (!session?.user?.id && process.env.NODE_ENV === 'development') {
+    const user = await prisma.user.findFirst({ select: { id: true, email: true } });
+    if (user) {
+      session = {
+        user: { id: user.id, email: user.email }
+      } as any;
+    }
+  }
+  return session;
+}


### PR DESCRIPTION
## Summary
- move SessionProvider into client Providers and add dev session fallback
- update workspace APIs to use unified session helper
- document local setup and add db scripts

## Testing
- `npm ci`
- `DATABASE_URL="file:./prisma/dev.db" npx prisma db push`
- `DATABASE_URL="file:./prisma/dev.db" npm run db:seed`
- `DATABASE_URL="file:./prisma/dev.db" npm run dev` *(terminated after curl tests)*
- `curl -s http://localhost:3000/api/health`
- `curl -s http://localhost:3000/api/auth/session`
- `curl -s http://localhost:3000/api/workspace/debug`
- `curl -s http://localhost:3000/api/workspace/boards`


------
https://chatgpt.com/codex/tasks/task_e_68b21529f6ec8321b496b2b65f25b820