### PR TITLE
fix: ensure profile feed displays posts

### DIFF
--- a/app/perfil/page.tsx
+++ b/app/perfil/page.tsx
@@ -7,9 +7,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
-import { ProfileHeader } from '@/components/perfil/ProfileHeader'
+import ProfileHeader from '@/components/perfil/ProfileHeader'
 import { ProfileFeed } from '@/components/perfil/ProfileFeed'
-import { AchievementCard } from '@/components/perfil/AchievementCard'
+import AchievementCard from '@/components/perfil/AchievementCard'
 import { Trophy, Users, FileText, BarChart3, Award, Heart } from 'lucide-react'
 
 const mockUser = {
@@ -172,6 +172,36 @@ const mockAchievements = [
   }
 ]
 
+// Mock posts used to display sample content in the profile feed
+const mockPosts = [
+  {
+    id: '1',
+    content: '¡Hola comunidad cantutina! Este es mi primer post.',
+    author: {
+      name: mockUser.name,
+      username: mockUser.username,
+      avatar: mockUser.avatar
+    },
+    createdAt: 'Hace 2 horas',
+    likes: 12,
+    comments: 3,
+    shares: 1
+  },
+  {
+    id: '2',
+    content: 'Estudiando para el examen de cálculo. ¿Recomendaciones?',
+    author: {
+      name: 'Carlos Pérez',
+      username: 'carlosperez',
+      avatar: 'https://images.unsplash.com/photo-1502685104226-ee32379fefbe?w=150&h=150&fit=crop&crop=face'
+    },
+    createdAt: 'Hace 1 día',
+    likes: 8,
+    comments: 5,
+    shares: 0
+  }
+]
+
 const mockStats = {
   coursesCompleted: 23,
   challengesCompleted: 45,
@@ -327,8 +357,8 @@ export default function PerfilPage() {
           {/* Right Column - Feed and Achievements */}
           <div className="lg:col-span-2 space-y-6">
             {/* Profile Feed */}
-            <ProfileFeed 
-              posts={[]} // TODO: Cargar posts reales del usuario
+            <ProfileFeed
+              posts={mockPosts}
               isOwnProfile={true}
               username={user.username}
             />

--- a/src/components/perfil/ProfileFeed.tsx
+++ b/src/components/perfil/ProfileFeed.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import { MessageCircle, Heart, Share, MoreHorizontal } from 'lucide-react';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';


### PR DESCRIPTION
## Summary
- fix imports and add mock posts in profile page
- convert profile feed into client component
- wire profile feed to show mock posts and composer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Module not found: Can't resolve '@radix-ui/react-alert-dialog')*


------
https://chatgpt.com/codex/tasks/task_e_68b26e88646c83218c2762ffa65d25ac