### PR TITLE
Fix profile feed rendering and publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,5 @@
 - Rename "Espacio Personal" navigation item to "Workspace" and fix related links.
 - Wrap root layout with SessionProvider and improve workspace board loading to prevent endless "Cargando..." state.
 - Move SessionProvider into client Providers and add development session fallback so workspace loads without RSC errors.
+- Fetch profile feed posts from API, fix AchievementCard import, and enable publishing from user profiles.
 

--- a/app/perfil/page.tsx
+++ b/app/perfil/page.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button'
 import { toast } from 'sonner'
 import { ProfileHeader } from '@/components/perfil/ProfileHeader'
 import { ProfileFeed } from '@/components/perfil/ProfileFeed'
-import { AchievementCard } from '@/components/perfil/AchievementCard'
+import AchievementCard from '@/components/perfil/AchievementCard'
 import { Trophy, Users, FileText, BarChart3, Award, Heart } from 'lucide-react'
 
 const mockUser = {
@@ -327,8 +327,7 @@ export default function PerfilPage() {
           {/* Right Column - Feed and Achievements */}
           <div className="lg:col-span-2 space-y-6">
             {/* Profile Feed */}
-            <ProfileFeed 
-              posts={[]} // TODO: Cargar posts reales del usuario
+            <ProfileFeed
               isOwnProfile={true}
               username={user.username}
             />

--- a/app/u/[username]/page.tsx
+++ b/app/u/[username]/page.tsx
@@ -5,10 +5,11 @@ import { useParams } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { MapPin, Calendar, GraduationCap, Users, FileText, Trophy, BarChart3, Star, Award, Heart } from 'lucide-react'
+import { MapPin, Calendar, GraduationCap, Users, FileText, Trophy, BarChart3, Star, Award, Heart, Target, Zap, BookOpen } from 'lucide-react'
 import { ProfileHeader } from '@/components/perfil/ProfileHeader'
 import { ProfileFeed } from '@/components/perfil/ProfileFeed'
 import AchievementCard from '@/components/perfil/AchievementCard'
+import { toast } from 'sonner'
 
 interface PublicUser {
   id: string
@@ -223,8 +224,7 @@ export default function PublicProfilePage() {
           {/* Right Column - Feed and Achievements */}
           <div className="lg:col-span-2 space-y-6">
             {/* Profile Feed */}
-            <ProfileFeed 
-              posts={[]} // TODO: Cargar posts reales del usuario
+            <ProfileFeed
               isOwnProfile={false}
               username={user.username}
             />


### PR DESCRIPTION
## Summary
- fix AchievementCard import on profile page
- load profile feed posts from API and enable Composer
- document profile feed fix in changelog

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b26e88646c83218c2762ffa65d25ac