### PR TITLE
Asegurar rutas protegidas y documentar autenticación

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,4 +23,5 @@
 - Wrap root layout with SessionProvider and improve workspace board loading to prevent endless "Cargando..." state.
 - Move SessionProvider into client Providers and add development session fallback so workspace loads without RSC errors.
 - Fetch profile feed posts from API, fix AchievementCard import, and enable publishing from user profiles.
+- Centralize route protection with middleware, isolate auth layout, and add automated checks for public/private access.
 

--- a/README-auth.md
+++ b/README-auth.md
@@ -1,0 +1,29 @@
+# Autenticación y rutas
+
+Este proyecto utiliza **NextAuth** y middleware para proteger rutas. Las rutas públicas pueden visitarse sin iniciar sesión; las protegidas redirigen a `/auth/login`.
+
+## Rutas públicas
+
+- `/`
+- `/auth/*`
+- `/u/[username]`
+- `/post/[id]`
+- `/notes/[id]`
+- `/feed/public`
+- Páginas informativas: `/about`, `/contact`, `/privacy`, `/terms`, `/cookies`, `/help`
+
+## Rutas protegidas
+
+- `/feed`
+- `/perfil`
+- `/workspace`
+- `/settings`
+- Otras secciones con acciones de usuario (`/notifications`, `/bookmarks`, `clubs/*`, etc.)
+
+## Desarrollo vs producción
+
+En desarrollo puede activarse una sesión simulada con `DEV_MOCK_SESSION=true` para navegar sin autenticación real. En producción siempre se requiere una sesión válida.
+
+## Verificación
+
+Ejecuta `npm run check-auth` con el servidor en marcha. El script verifica accesos públicos, redirecciones y que la API solo exponga contenido `PUBLIC` cuando no hay sesión.

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -92,3 +92,4 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}

--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -39,7 +39,7 @@ export async function GET(request: NextRequest) {
       author: searchParams.get('author'),
     });
 
-    let where: any = {};
+    const where: any = {};
 
     if (!session?.user?.id) {
       // For unauthenticated users, only show PUBLIC posts

--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Autenticación - CRUNEVO'
+}
+
+export default function AuthLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      {children}
+    </div>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import Providers from "./providers";
-import { MainLayout } from "../src/components/layout/MainLayout";
+import LayoutSelector from "../src/components/layout/LayoutSelector";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -29,9 +29,9 @@ export default function RootLayout({
     <html lang="es" className={inter.variable}>
       <body className="font-sans antialiased bg-gray-50">
         <Providers>
-          <MainLayout>
+          <LayoutSelector>
             {children}
-          </MainLayout>
+          </LayoutSelector>
         </Providers>
       </body>
     </html>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -75,15 +75,6 @@ export default function SettingsPage() {
     delete: false
   });
 
-  // Redirect if not authenticated
-  useEffect(() => {
-    if (status === 'loading') return;
-    if (status === 'unauthenticated') {
-      router.push('/auth/login');
-      return;
-    }
-  }, [status, router]);
-
   // Load user settings
   useEffect(() => {
     const loadSettings = async () => {
@@ -107,6 +98,11 @@ export default function SettingsPage() {
       loadSettings();
     }
   }, [status]);
+
+  // Middleware handles redirects; do not render for unauthenticated users
+  if (status === 'unauthenticated') {
+    return null;
+  }
 
   const handleSettingsUpdate = async (section: keyof UserSettings, data: any) => {
     setSaving(true);

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useSession } from 'next-auth/react';
 import { Plus, Edit3, Check, Grid3X3, Maximize2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -204,18 +203,9 @@ export default function WorkspacePage() {
     );
   }
 
-  if (status === 'unauthenticated' && process.env.NODE_ENV !== 'development') {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <Card className="p-8 text-center">
-          <h1 className="text-2xl font-bold mb-4">Acceso Requerido</h1>
-          <p className="text-gray-600 mb-4">Debes iniciar sesión para acceder al Workspace</p>
-          <Button onClick={() => (window.location.href = '/auth/login')}>
-            Iniciar Sesión
-          </Button>
-        </Card>
-      </div>
-    );
+  // Middleware already protects this route; render nothing for unauthenticated users
+  if (status === 'unauthenticated') {
+    return null
   }
 
   if (error) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,18 +3,22 @@ import { NextResponse } from "next/server"
 
 // Rutas públicas que no requieren autenticación
 const publicRoutes = [
-  "/",
-  "/auth/login",
-  "/auth/register", 
-  "/auth/forgot-password",
-  "/auth/reset-password"
+  '/',
+  '/feed/public',
+  '/about',
+  '/contact',
+  '/privacy',
+  '/terms',
+  '/cookies',
+  '/help'
 ]
 
 // Patrones de rutas públicas (usando regex)
 const publicPatterns = [
+  /^\/auth(\/.*)?$/, // /auth/*
   /^\/u\/[^/]+$/, // /u/[username]
   /^\/post\/[^/]+$/, // /post/[id]
-  /^\/notes\/[^/]+$/ // /notes/[id] (solo si la nota es pública)
+  /^\/notes\/[^/]+$/ // /notes/[id]
 ]
 
 export default withAuth(

--- a/src/components/layout/LayoutSelector.tsx
+++ b/src/components/layout/LayoutSelector.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { MainLayout } from './MainLayout'
+
+interface Props {
+  children: React.ReactNode
+}
+
+export function LayoutSelector({ children }: Props) {
+  const pathname = usePathname()
+  const isAuthRoute = pathname.startsWith('/auth')
+  return isAuthRoute ? <>{children}</> : <MainLayout>{children}</MainLayout>
+}
+
+export default LayoutSelector


### PR DESCRIPTION
## Resumen
- Separar layout de autenticación y usar selector de layouts
- Centralizar rutas públicas en `middleware` y quitar formularios de login incrustados
- Mejorar script `check-auth` y documentar matriz de rutas

## Testing
- `npm run lint`
- `npm run check-auth` *(falla: server not responding)*

------
https://chatgpt.com/codex/tasks/task_e_68b2791291448321b950d879855ea27e