### PR TITLE
Fix profile and notification API usage

### DIFF
--- a/app/api/marketplace/orders/[id]/route.ts
+++ b/app/api/marketplace/orders/[id]/route.ts
@@ -86,7 +86,7 @@ export async function GET(
     }
 
     // Parsear dirección de envío si existe
-    let parsedOrder = {
+    const parsedOrder = {
       ...order,
       shippingAddress: order.shippingAddress 
         ? JSON.parse(order.shippingAddress) 
@@ -168,7 +168,7 @@ export async function PUT(
     }
 
     // Si se cancela la orden, restaurar stock y Crolars
-    let updateData: any = {
+    const updateData: any = {
       status,
       trackingNumber,
       notes

--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -34,7 +34,7 @@ export async function GET(request: NextRequest) {
     const queryParams = {
       page: searchParams.get('page') || '1',
       limit: searchParams.get('limit') || '20',
-      type: searchParams.get('type'),
+      type: searchParams.get('type') || undefined,
       unreadOnly: searchParams.get('unreadOnly') === 'true'
     };
 

--- a/app/api/notifications/stream/route.ts
+++ b/app/api/notifications/stream/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from 'next/server';
+import { addConnection, removeConnection } from '@/lib/notificationStream';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const userId = searchParams.get('userId');
+
+  if (!userId) {
+    return new Response('userId query parameter is required', { status: 400 });
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      addConnection(userId, controller);
+      controller.enqueue('event: connected\ndata: ok\n\n');
+    },
+    cancel() {
+      removeConnection(userId);
+    }
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/app/perfil/page.tsx
+++ b/app/perfil/page.tsx
@@ -192,18 +192,18 @@ export default function PerfilPage() {
   useEffect(() => {
     const fetchUserProfile = async () => {
       try {
-        if (!session?.user?.email) {
+        if (!session?.user?.id) {
           // Use mock data for development
           setUser(mockUser)
           setLoading(false)
           return
         }
 
-        const response = await fetch(`/api/users/${session.user.email}`)
+        const response = await fetch('/api/user/profile')
         if (!response.ok) {
           throw new Error('Failed to fetch user profile')
         }
-        const userData = await response.json()
+        const { user: userData } = await response.json()
         setUser(userData)
       } catch (err) {
         console.error('Error fetching user profile:', err)

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef, useCallback } from 'react';
+import { useSession } from 'next-auth/react';
 import { Plus, Edit3, Check, Grid3X3, Maximize2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -14,13 +14,13 @@ interface MainLayoutProps {
 }
 
 export function MainLayout({ children }: MainLayoutProps) {
-  const { status } = useSession();
+  const { data: session, status } = useSession();
 
   useEffect(() => {
-    if (status !== 'authenticated') return;
+    if (status !== 'authenticated' || !session?.user?.id) return;
 
     // Initialize notification service only when authenticated
-    notificationService.connect();
+    notificationService.connect(session.user.id);
 
     // Request notification permissions
     notificationService.requestNotificationPermission();
@@ -29,7 +29,7 @@ export function MainLayout({ children }: MainLayoutProps) {
     return () => {
       notificationService.disconnect();
     };
-  }, [status]);
+  }, [status, session?.user?.id]);
   
   return (
     <div className="min-h-screen bg-crunevo-gradient">

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -17,10 +17,10 @@ class NotificationService {
     // No inicializar automáticamente, esperar a que el usuario se conecte
   }
 
-  private async initializeSSE() {
+  private async initializeSSE(userId: string) {
     try {
       // Conectar a Server-Sent Events
-      this.eventSource = new EventSource('/api/notifications/stream');
+      this.eventSource = new EventSource(`/api/notifications/stream?userId=${userId}`);
 
       this.eventSource.onopen = () => {
         console.log('Connected to notification stream');
@@ -48,7 +48,7 @@ class NotificationService {
         // Intentar reconectar después de 5 segundos
         setTimeout(() => {
           if (this.eventSource?.readyState === EventSource.CLOSED) {
-            this.initializeSSE();
+            this.initializeSSE(userId);
           }
         }, 5000);
       };
@@ -59,9 +59,9 @@ class NotificationService {
     }
   }
 
-  async connect() {
+  async connect(userId: string) {
     if (!this.isConnected) {
-      await this.initializeSSE();
+      await this.initializeSSE(userId);
       // Cargar notificaciones existentes
       await this.loadNotifications();
     }


### PR DESCRIPTION
## Summary
- Fix profile page to use authenticated profile endpoint
- Import useSession in workspace page
- Implement SSE notifications stream and update notification service
- Normalize notifications API query params
- Adjust order route const usage for lint

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b299bd6f74832184bdbd51f9584ac8