### PR TITLE
feat(profile): inline editing and achievements pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,4 +26,8 @@
 - Centralize route protection with middleware, isolate auth layout, and add automated checks for public/private access.
 - Replace default "U" avatar with generic user icon and direct unauthenticated profile clicks to login.
 - Guard missing profile fields and handle empty interests to prevent runtime errors on the profile page.
+- Restore inline profile editing on `/perfil` without redirecting to settings.
+- Remove quick configuration card from profile page and centralize settings under `/settings`.
+- Reintroduce achievements tab and dedicated pages at `/perfil/logros` and `/u/[username]/logros`.
+- Correct camera icon alignment on profile avatar and banner.
 

--- a/app/perfil/logros/page.tsx
+++ b/app/perfil/logros/page.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import AchievementCard from '@/components/perfil/AchievementCard'
+import BadgeCollection from '@/components/gamification/BadgeCollection'
+import { Trophy, Award } from 'lucide-react'
+
+const mockAchievements = [
+  {
+    id: '1',
+    title: 'Bienvenido a La Cantuta',
+    description: 'Completaste tu registro en la Universidad Nacional de Educación',
+    icon: 'Trophy',
+    category: 'milestone' as const,
+    difficulty: 'easy' as const,
+    points: 50,
+    earned: true,
+    earnedDate: '2024-01-15',
+    claimed: false,
+    claimable: true,
+    reward: { xp: 50, crolars: 10 }
+  },
+  {
+    id: '2',
+    title: 'Futuro Educador',
+    description: 'Completaste 10 módulos de formación pedagógica',
+    icon: 'Star',
+    category: 'learning' as const,
+    difficulty: 'medium' as const,
+    points: 100,
+    earned: true,
+    earnedDate: '2024-01-20',
+    claimed: true,
+    claimable: true,
+    reward: { xp: 100, crolars: 25 }
+  },
+  {
+    id: '3',
+    title: 'Maestro de la Tecnología',
+    description: 'Domina 50 conceptos de programación educativa',
+    icon: 'Award',
+    category: 'challenge' as const,
+    difficulty: 'hard' as const,
+    points: 500,
+    earned: false,
+    progress: 23,
+    maxProgress: 50,
+    claimed: false,
+    claimable: false,
+    reward: { xp: 500, crolars: 100 }
+  },
+  {
+    id: '4',
+    title: 'Compañero Solidario',
+    description: 'Ayuda a 5 estudiantes cantutinos en el foro académico',
+    icon: 'Award',
+    category: 'social' as const,
+    difficulty: 'medium' as const,
+    points: 150,
+    earned: true,
+    earnedDate: '2024-01-25',
+    claimed: false,
+    claimable: true,
+    reward: { xp: 150, crolars: 30 }
+  }
+]
+
+export default function ProfileAchievementsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Trophy className="h-5 w-5 text-yellow-500" />
+              Logros
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {mockAchievements.map((achievement) => (
+                <AchievementCard key={achievement.id} achievement={achievement} />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Award className="h-5 w-5 text-blue-500" />
+              Insignias
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <BadgeCollection />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/perfil/page.tsx
+++ b/app/perfil/page.tsx
@@ -13,7 +13,7 @@ import { ProfileFeed } from '@/components/perfil/ProfileFeed'
 import ProfileEditor from '@/components/perfil/ProfileEditor'
 import AchievementCard from '@/components/perfil/AchievementCard'
 import BadgeCollection from '@/components/gamification/BadgeCollection'
-import { Trophy, Users, FileText, BarChart3, Award, Heart, Settings, Target } from 'lucide-react'
+import { Trophy, Users, FileText, BarChart3, Award, Heart, Target } from 'lucide-react'
 
 interface UserProfile {
   name: string
@@ -323,10 +323,12 @@ export default function PerfilPage() {
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-4xl mx-auto space-y-6">
           {/* Profile Header */}
-          <ProfileHeader 
+          <ProfileHeader
             user={user}
-            mode="edit"
+            mode={isEditing ? 'edit' : 'view'}
             onEdit={handleEditProfile}
+            onBannerChange={(banner) => setUser(prev => prev ? { ...prev, banner } : prev)}
+            onAvatarChange={(avatar) => setUser(prev => prev ? { ...prev, avatar } : prev)}
           />
 
           {/* Inline Profile Editor */}
@@ -337,7 +339,7 @@ export default function PerfilPage() {
               </CardHeader>
               <CardContent>
                 <ProfileEditor
-                  user={user}
+                  profile={user}
                   onSave={handleSaveProfile}
                   onCancel={handleCancelEdit}
                 />
@@ -347,7 +349,7 @@ export default function PerfilPage() {
 
           {/* Profile Tabs */}
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-4">
+            <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="profile" className="flex items-center gap-2">
                 <Users className="h-4 w-4" />
                 Perfil
@@ -359,10 +361,6 @@ export default function PerfilPage() {
               <TabsTrigger value="statistics" className="flex items-center gap-2">
                 <BarChart3 className="h-4 w-4" />
                 Estadísticas
-              </TabsTrigger>
-              <TabsTrigger value="settings" className="flex items-center gap-2">
-                <Settings className="h-4 w-4" />
-                Configuración
               </TabsTrigger>
             </TabsList>
 
@@ -391,49 +389,23 @@ export default function PerfilPage() {
 
               {/* Profile Feed */}
               <ProfileFeed userId={user?.id} />
-
-              {/* Recent Achievements Summary */}
-              <Card>
-                <CardHeader className="flex flex-row items-center justify-between">
-                  <CardTitle className="flex items-center gap-2">
-                    <Trophy className="h-5 w-5 text-yellow-500" />
-                    Logros Recientes
-                  </CardTitle>
-                  <Button 
-                    variant="outline" 
-                    size="sm"
-                    onClick={() => router.push('/achievements')}
-                  >
-                    Ver todos
-                  </Button>
-                </CardHeader>
-                <CardContent>
-                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                    {mockAchievements.slice(0, 3).map((achievement) => (
-                      <AchievementCard
-                        key={achievement.id}
-                        achievement={achievement}
-                        onClaim={handleClaimAchievement}
-                        isClaimed={claimedAchievements.has(achievement.id)}
-                      />
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
             </TabsContent>
 
             {/* Achievements Tab Content */}
             <TabsContent value="achievements" className="space-y-6">
               <Card>
-                <CardHeader>
+                <CardHeader className="flex items-center justify-between">
                   <CardTitle className="flex items-center gap-2">
                     <Trophy className="h-5 w-5 text-yellow-500" />
-                    Todos los Logros
+                    Logros
                   </CardTitle>
+                  <Button variant="outline" size="sm" onClick={() => router.push('/perfil/logros')}>
+                    Ver más
+                  </Button>
                 </CardHeader>
                 <CardContent>
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {mockAchievements.map((achievement) => (
+                    {mockAchievements.slice(0, 6).map((achievement) => (
                       <AchievementCard
                         key={achievement.id}
                         achievement={achievement}
@@ -522,31 +494,6 @@ export default function PerfilPage() {
                   </CardContent>
                 </Card>
               </div>
-            </TabsContent>
-
-            {/* Settings Tab Content */}
-            <TabsContent value="settings" className="space-y-6">
-              <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <Settings className="h-5 w-5 text-gray-500" />
-                    Configuración
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-center py-8">
-                    <Settings className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                    <h3 className="text-lg font-medium text-gray-900 mb-2">Configuración del Perfil</h3>
-                    <p className="text-gray-600 mb-6">Administra tu privacidad y configuración avanzada</p>
-                    <Button 
-                      onClick={() => router.push('/settings')}
-                      className="w-full max-w-xs"
-                    >
-                      Ir a Configuración
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
             </TabsContent>
           </Tabs>
         </div>

--- a/app/u/[username]/logros/page.tsx
+++ b/app/u/[username]/logros/page.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import AchievementCard from '@/components/perfil/AchievementCard'
+import { Trophy } from 'lucide-react'
+
+const mockAchievements = [
+  {
+    id: '1',
+    title: 'Primer Paso',
+    description: 'Completaste tu primer desafío',
+    icon: 'Trophy',
+    unlockedAt: 'Enero 2024',
+    rarity: 'common' as const
+  },
+  {
+    id: '2',
+    title: 'Estudiante Dedicado',
+    description: 'Completaste 10 desafíos',
+    icon: 'Star',
+    unlockedAt: 'Febrero 2024',
+    rarity: 'rare' as const
+  },
+  {
+    id: '3',
+    title: 'Maestro del Código',
+    description: 'Resolviste 50 problemas de programación',
+    icon: 'Target',
+    unlockedAt: 'Marzo 2024',
+    rarity: 'epic' as const
+  }
+]
+
+interface PageProps {
+  params: { username: string }
+}
+
+export default function PublicAchievementsPage({ params }: PageProps) {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-5xl mx-auto px-4 py-8">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Trophy className="h-5 w-5 text-yellow-500" />
+              Logros de {params.username}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {mockAchievements.map((achievement) => (
+                <AchievementCard key={achievement.id} achievement={achievement} showDetails={false} />
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/u/[username]/page.tsx
+++ b/app/u/[username]/page.tsx
@@ -8,8 +8,7 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { ProfileHeader } from '@/components/perfil/ProfileHeader'
 import { ProfileFeed } from '@/components/perfil/ProfileFeed'
-import AchievementCard from '@/components/perfil/AchievementCard'
-import { toast } from 'sonner'
+import Link from 'next/link'
 
 interface PublicUser {
   id: string
@@ -28,34 +27,6 @@ interface PublicUser {
   following?: number
   posts?: number
 }
-
-// Mock achievements and stats for demo
-const mockAchievements = [
-  {
-    id: '1',
-    title: 'Primer Paso',
-    description: 'Completaste tu primer desafío',
-    icon: 'Trophy',
-    unlockedAt: 'Enero 2024',
-    rarity: 'common' as const
-  },
-  {
-    id: '2',
-    title: 'Estudiante Dedicado',
-    description: 'Completaste 10 desafíos',
-    icon: 'Star',
-    unlockedAt: 'Febrero 2024',
-    rarity: 'rare' as const
-  },
-  {
-    id: '3',
-    title: 'Maestro del Código',
-    description: 'Resolviste 50 problemas de programación',
-    icon: 'Target',
-    unlockedAt: 'Marzo 2024',
-    rarity: 'epic' as const
-  }
-]
 
 const mockStats = [
   { label: 'Desafíos Completados', value: '67', icon: 'Target' },
@@ -198,7 +169,7 @@ export default async function PublicProfilePage({ params }: PageProps) {
             </Card>
           </div>
 
-          {/* Right Column - Feed and Achievements */}
+          {/* Right Column - Feed */}
           <div className="lg:col-span-2 space-y-6">
             {/* Profile Feed */}
             <ProfileFeed
@@ -207,23 +178,11 @@ export default async function PublicProfilePage({ params }: PageProps) {
               isPublicView={!session}
             />
 
-            {/* Recent Achievements */}
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-lg font-semibold">Logros Destacados</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {mockAchievements.map((achievement) => (
-                    <AchievementCard 
-                      key={achievement.id} 
-                      achievement={achievement} 
-                      showDetails={false}
-                    />
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
+            <div className="text-right">
+              <Button variant="outline" asChild>
+                <Link href={`/u/${user.username}/logros`}>Ver logros</Link>
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/perfil/ProfileHeader.tsx
+++ b/src/components/perfil/ProfileHeader.tsx
@@ -99,7 +99,7 @@ export function ProfileHeader({ user, mode, onEdit, onViewPublic, onBannerChange
           <Button
             variant="secondary"
             size="sm"
-            className="absolute top-4 right-4 bg-black/50 hover:bg-black/70 text-white border-0"
+            className="absolute top-4 right-4 bg-black/50 hover:bg-black/70 text-white border-0 flex items-center justify-center"
             onClick={handleBannerEdit}
           >
             <Camera className="h-4 w-4" />
@@ -123,7 +123,7 @@ export function ProfileHeader({ user, mode, onEdit, onViewPublic, onBannerChange
                 <Button
                   variant="secondary"
                   size="sm"
-                  className="absolute bottom-2 right-2 h-8 w-8 rounded-full p-0 bg-white shadow-md hover:bg-gray-50"
+                  className="absolute bottom-2 right-2 h-8 w-8 rounded-full p-0 bg-white shadow-md hover:bg-gray-50 flex items-center justify-center"
                   onClick={handleAvatarEdit}
                 >
                   <Camera className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- allow editing profile info inline on `/perfil` without redirect
- remove quick config card and expose logros tab with "Ver más" link
- add achievements pages for owner and public profiles
- align avatar and banner camera icons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2a8a2ead083219cee93e94883d78d