### PR TITLE
Corrige errores de perfil y publicación

### DIFF
--- a/app/perfil/page.tsx
+++ b/app/perfil/page.tsx
@@ -388,7 +388,10 @@ export default function PerfilPage() {
               )}
 
               {/* Profile Feed */}
-              <ProfileFeed userId={user?.id} />
+              <ProfileFeed
+                isOwnProfile={session?.user?.id === user?.id}
+                username={user.username}
+              />
             </TabsContent>
 
             {/* Achievements Tab Content */}

--- a/src/components/gamification/BadgeCollection.tsx
+++ b/src/components/gamification/BadgeCollection.tsx
@@ -22,7 +22,7 @@ import {
 import { Badge as BadgeType } from '@/types/gamification'
 
 interface BadgeCollectionProps {
-  badges: BadgeType[]
+  badges?: BadgeType[]
   totalBadges?: number
   className?: string
 }
@@ -115,7 +115,7 @@ const ALL_BADGES: BadgeType[] = [
   }
 ]
 
-export default function BadgeCollection({ badges, totalBadges = 50, className = '' }: BadgeCollectionProps) {
+export default function BadgeCollection({ badges = [], totalBadges = 50, className = '' }: BadgeCollectionProps) {
   const [searchTerm, setSearchTerm] = useState('')
   const [filterCategory, setFilterCategory] = useState<string>('all')
   const [filterRarity, setFilterRarity] = useState<string>('all')

--- a/src/components/perfil/ProfileEditor.tsx
+++ b/src/components/perfil/ProfileEditor.tsx
@@ -184,7 +184,7 @@ export default function ProfileEditor({ profile, onSave, onCancel }: ProfileEdit
 
   const handleViewPublic = () => {
     // Extract username from email or use a default
-    const username = formData.email.split('@')[0] || 'usuario'
+    const username = formData.email?.split('@')[0] || 'usuario'
     router.push(`/u/${username}`)
   }
 
@@ -194,7 +194,7 @@ export default function ProfileEditor({ profile, onSave, onCancel }: ProfileEdit
       <ProfileHeader 
         user={{
           name: formData.name,
-          username: formData.email.split('@')[0] || 'usuario',
+          username: formData.email?.split('@')[0] || 'usuario',
           avatar: avatarPreview || formData.avatar,
           banner: bannerPreview || formData.banner,
           bio: formData.bio,


### PR DESCRIPTION
## Summary
- Evita fallos cuando la lista de insignias está vacía
- Maneja correos faltantes al obtener el nombre de usuario
- Activa el formulario de publicación en el perfil propio

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2ab1ab24c8321915642fd3e26a4d1