### PR TITLE
fix: handle missing social links in ProfileEditor

### DIFF
--- a/src/components/perfil/ProfileEditor.tsx
+++ b/src/components/perfil/ProfileEditor.tsx
@@ -54,7 +54,12 @@ interface ProfileEditorProps {
 
 export default function ProfileEditor({ profile, onSave, onCancel }: ProfileEditorProps) {
   const router = useRouter()
-  const [formData, setFormData] = useState<UserProfile & { faculty?: string }>({ ...profile, faculty: profile.faculty || '' })
+  // Initialize socialLinks to an empty object to avoid undefined errors when editing
+  const [formData, setFormData] = useState<UserProfile & { faculty?: string }>({
+    ...profile,
+    faculty: profile.faculty || '',
+    socialLinks: profile.socialLinks || {}
+  })
   const [newInterest, setNewInterest] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
@@ -71,7 +76,7 @@ export default function ProfileEditor({ profile, onSave, onCancel }: ProfileEdit
     setFormData(prev => ({
       ...prev,
       socialLinks: {
-        ...prev.socialLinks,
+        ...(prev.socialLinks || {}),
         [platform]: value
       }
     }))


### PR DESCRIPTION
## Summary
- initialize missing `socialLinks` to prevent runtime errors when editing a profile
- guard social link updates to avoid undefined spreads

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2b13401808321a928a3b05be04cd8