### PR TITLE
Fix gamification test route

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -36,5 +36,7 @@ DATABASE_URL="file:./prisma/dev.db"
 - `GET /api/auth/session`
 - `GET /api/workspace/debug`
 - `GET /api/workspace/boards`
+- `GET /api/test/gamification`
+- `POST /api/test/gamification`
 
 En desarrollo, si no hay sesión activa, las rutas de `workspace` utilizan el primer usuario de la base de datos como sesión simulada.

--- a/app/api/test/gamification/route.ts
+++ b/app/api/test/gamification/route.ts
@@ -126,3 +126,7 @@ export async function GET() {
       body: {
         eventType: 'string (required)',
         data: 'object (optional)'
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- close missing braces in gamification test API route
- document gamification test endpoints

## Testing
- `npm run lint` *(fails: 'eventData' is never reassigned; expected an assignment or function call)*
- `npm run build` *(fails: can't resolve some modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f3e72988321a239761ae455f35f