### PR TITLE
fix: align gamification component imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix TypeScript build errors across project.
 - Correct Feed import in App.tsx to use named export.
+- Fix NotificationCenter and gamification component imports to prevent invalid element type errors.
 - Move notification stream helpers to `src/lib/notificationStream.ts`.
 - Remove unsupported fields from auth registration and welcome transaction.
 - Align gamification leaderboard and achievement data with defined types.

--- a/app/perfil/gamification/page.tsx
+++ b/app/perfil/gamification/page.tsx
@@ -21,9 +21,9 @@ import {
 // Importar componentes de gamificación
 import LevelProgress from '@/components/gamification/LevelProgress'
 import BadgeCollection from '@/components/gamification/BadgeCollection'
-import GamificationNotifications from '@/components/gamification/GamificationNotifications'
-import Leaderboard from '@/components/gamification/Leaderboard'
-import AchievementSystem from '@/components/gamification/AchievementSystem'
+import { GamificationNotifications } from '@/components/gamification/GamificationNotifications'
+import { Leaderboard } from '@/components/gamification/Leaderboard'
+import { AchievementSystem } from '@/components/gamification/AchievementSystem'
 
 // Importar tipos y servicios
 import { User, UserStats, Notification, Leaderboard as LeaderboardType } from '@/types/gamification'

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Badge } from '@/components/ui/badge';
-import NotificationCenter from '@/components/notifications/NotificationCenter';
+import { NotificationCenter } from '@/components/notifications/NotificationCenter';
 
 export function Navbar() {
   const { data: session } = useSession();


### PR DESCRIPTION
## Summary
- use named import for NotificationCenter in Navbar
- align gamification page imports with named component exports
- document import fixes in changelog

## Testing
- `npm run lint` *(fails: 'eventData' is never reassigned, 'Expected an assignment or function call and instead saw an expression')*
- `npx eslint src/components/layout/Navbar.tsx app/perfil/gamification/page.tsx CHANGELOG.md`


------
https://chatgpt.com/codex/tasks/task_e_68b35567b0a08321860d11006696e497