### PR TITLE
fix: resolve missing icon and toast import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,4 +32,5 @@
 - Remove quick configuration card from profile page and centralize settings under `/settings`.
 - Reintroduce achievements tab and dedicated pages at `/perfil/logros` and `/u/[username]/logros`.
 - Correct camera icon alignment on profile avatar and banner.
+- Replace missing Fire icon with FlameIcon and use proper NotificationToast import to resolve development runtime errors.
 

--- a/app/api/gamification/events/route.ts
+++ b/app/api/gamification/events/route.ts
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Validar datos específicos según el tipo de evento
-    let eventData: any = { userId: targetUserId, ...data };
+    const eventData: any = { userId: targetUserId, ...data };
 
     switch (eventType) {
       case 'post_created':

--- a/components/feed/TrendingSidebar.tsx
+++ b/components/feed/TrendingSidebar.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Avatar } from '@/components/ui/avatar';
 import {
   TrendingUpIcon,
-  FireIcon,
+  FlameIcon,
   UsersIcon,
   BookOpenIcon,
   MessageSquareIcon,
@@ -173,7 +173,8 @@ export function TrendingSidebar() {
       {/* Apuntes Trending */}
       <Card className="p-4">
         <div className="flex items-center space-x-2 mb-4">
-          <FireIcon className="h-5 w-5 text-red-500" />
+          {/* lucide-react does not export a FireIcon; use FlameIcon instead */}
+          <FlameIcon className="h-5 w-5 text-red-500" />
           <h3 className="font-semibold text-gray-800">Apuntes Populares</h3>
         </div>
         <div className="space-y-4">

--- a/lib/gamification-worker.ts
+++ b/lib/gamification-worker.ts
@@ -251,7 +251,8 @@ export const gamificationWorker = GamificationWorker.getInstance();
 // Función para inicializar el worker (llamar al inicio de la aplicación)
 export function initializeGamificationWorker(): void {
   console.log('[GamificationWorker] Initializing gamification worker...');
-  gamificationWorker; // Esto inicializa el singleton
+  // Touch the singleton to ensure initialization
+  gamificationWorker.getPendingJobs();
 }
 
 // Función para detener el worker (llamar al cerrar la aplicación)

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -6,7 +6,8 @@ import { Navbar } from './Navbar';
 import { Sidebar } from './Sidebar';
 import { Footer } from './Footer';
 import { FloatingActionButton } from './FloatingActionButton';
-import NotificationToast from '@/components/notifications/NotificationToast';
+// Use the NotificationToast component from the src tree
+import NotificationToast from '../notifications/NotificationToast';
 import { notificationService } from '@/services/notificationService';
 
 interface MainLayoutProps {


### PR DESCRIPTION
## Summary
- replace missing FireIcon with FlameIcon in trending sidebar
- import NotificationToast from src tree instead of root components
- clean lint errors in gamification worker and event route

## Testing
- `npm run lint`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68b36853a3108321881c541893a94795