### PR TITLE
fix: improve notification wiring and websocket errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,5 @@
 - Correct camera icon alignment on profile avatar and banner.
 - Replace missing Fire icon with FlameIcon and use proper NotificationToast import to resolve development runtime errors.
 
+- Ensure notification service connects correctly and improve WebSocket error handling.
+

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -234,8 +234,9 @@ export function useNotifications(): UseNotificationsReturn {
         }
       };
 
-      ws.onerror = (error) => {
-        console.error('Error en WebSocket:', error);
+      ws.onerror = (event) => {
+        const message = event instanceof ErrorEvent ? event.message : 'Network error';
+        console.error('Error en WebSocket:', message);
       };
     } catch (err) {
       console.error('Error setting up WebSocket:', err);

--- a/hooks/useWebSocketNotifications.ts
+++ b/hooks/useWebSocketNotifications.ts
@@ -92,8 +92,9 @@ export function useWebSocketNotifications() {
         }
       };
 
-      wsRef.current.onerror = (error) => {
-        console.error('WebSocket error:', error);
+      wsRef.current.onerror = (event) => {
+        const message = event instanceof ErrorEvent ? event.message : 'Network error';
+        console.error('WebSocket error:', message);
       };
     } catch (error) {
       console.error('Error creating WebSocket connection:', error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## Summary
- ensure `@/*` resolves to `src` for consistent service imports
- clarify WebSocket error logs to show meaningful messages
- record notification service fixes in changelog

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b36a48abd48321b1e076d6f831f326