### PR TITLE
feat: support login and signin routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Fix TypeScript build errors across project.
+- Redirect `/auth/signin` to `/auth/login` and update authentication routes.
 - Resolve component import mismatches and add API rate limiting helpers.
 - Correct Feed import in App.tsx to use named export.
 - Fix NotificationCenter and gamification component imports to prevent invalid element type errors.

--- a/README-auth.md
+++ b/README-auth.md
@@ -1,6 +1,6 @@
 # Autenticación y rutas
 
-Este proyecto utiliza **NextAuth** y middleware para proteger rutas. Las rutas públicas pueden visitarse sin iniciar sesión; las protegidas redirigen a `/auth/login`.
+Este proyecto utiliza **NextAuth** y middleware para proteger rutas. Las rutas públicas pueden visitarse sin iniciar sesión; las protegidas redirigen a `/auth/login` (también accesible como `/auth/signin`).
 
 ## Rutas públicas
 

--- a/app/auth/signin/page.tsx
+++ b/app/auth/signin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function SignInRedirectPage() {
+  redirect('/auth/login');
+}

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function SignUpRedirectPage() {
+  redirect('/auth/register');
+}

--- a/app/auth/verify-university/page.tsx
+++ b/app/auth/verify-university/page.tsx
@@ -25,7 +25,7 @@ export default function VerifyUniversityPage() {
   useEffect(() => {
     // Redirigir si no está autenticado
     if (status === 'unauthenticated') {
-      router.push('/auth/signin');
+      router.push('/auth/login');
     }
   }, [status, router]);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -77,7 +77,7 @@ export default async function HomePage() {
   
   // Si no hay sesión, redirigir al login
   if (!session) {
-    redirect('/auth/signin');
+    redirect('/auth/login');
   }
 
   return (

--- a/components/auth/ProtectedRoute.tsx
+++ b/components/auth/ProtectedRoute.tsx
@@ -56,10 +56,10 @@ export function ProtectedRoute({
           <CardContent className="space-y-4">
             <div className="flex flex-col space-y-2">
               <Button asChild>
-                <Link href="/auth/signin">Iniciar Sesión</Link>
+                <Link href="/auth/login">Iniciar Sesión</Link>
               </Button>
               <Button variant="outline" asChild>
-                <Link href="/auth/signup">Crear Cuenta</Link>
+                <Link href="/auth/register">Crear Cuenta</Link>
               </Button>
             </div>
             <div className="text-center">

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -38,7 +38,9 @@ const MODERATOR_ROUTES = [
 // Rutas públicas (no requieren autenticación)
 const PUBLIC_ROUTES = [
   '/',
+  '/auth/login',
   '/auth/signin',
+  '/auth/register',
   '/auth/signup',
   '/auth/forgot-password',
   '/api/auth',
@@ -64,9 +66,9 @@ export async function authMiddleware(request: NextRequest) {
   
   if (requiresAuth && !token) {
     // Redirigir a login si no está autenticado
-    const signInUrl = new URL('/auth/signin', request.url);
-    signInUrl.searchParams.set('callbackUrl', pathname);
-    return NextResponse.redirect(signInUrl);
+    const loginUrl = new URL('/auth/login', request.url);
+    loginUrl.searchParams.set('callbackUrl', pathname);
+    return NextResponse.redirect(loginUrl);
   }
 
   // Si está autenticado, verificar permisos adicionales


### PR DESCRIPTION
## Summary
- redirect `/auth/signin` to `/auth/login` and handle legacy `/auth/signup`
- update middleware and components to use `/auth/login`
- document new routes in auth README and changelog

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3a3bedab483218333b2084a9d5615