### PR TITLE
feat: improve notes viewer and upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add `/notes/upload` route and convert upload form to modal to avoid duplicate "Subir Apunte" buttons.
+- Wire "Ver" and "Descargar" actions in notes grid to open the viewer and download the first file.
 - Move Cantuta university data to root data/ directory so `npm run build` succeeds.
 - Fix TypeScript build errors across project.
 - Redirect `/auth/signin` to `/auth/login` and update authentication routes.

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,26 +1,13 @@
 'use client';
 
 import { useState } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useRouter } from 'next/navigation';
+import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import { 
-  Search, 
-  Upload, 
-  Filter,
-  FileText,
-  Image,
-  File,
-  Download,
-  Eye,
-  Star,
-  Calendar,
-  User
-} from 'lucide-react';
+import { Search, Upload, Filter } from 'lucide-react';
 import { NotesGrid } from '@/components/notes/NotesGrid';
 import { NotesFilters } from '@/components/notes/NotesFilters';
-import { NotesUpload } from '@/components/notes/NotesUpload';
 import { NotesViewer } from '@/components/notes/NotesViewer';
 
 // Mock data for selected note
@@ -90,7 +77,6 @@ const mockNote = {
 export default function NotesPage() {
   const [searchQuery, setSearchQuery] = useState('');
   const [showFilters, setShowFilters] = useState(false);
-  const [showUpload, setShowUpload] = useState(false);
   const [selectedNote, setSelectedNote] = useState<typeof mockNote | null>(null);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [selectedCareer, setSelectedCareer] = useState('all');
@@ -101,10 +87,7 @@ export default function NotesPage() {
     setSelectedNote(mockNote);
   };
 
-  const handleUploadSuccess = () => {
-    setShowUpload(false);
-    // Refresh notes list
-  };
+  const router = useRouter();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 to-blue-50 p-6">
@@ -143,8 +126,8 @@ export default function NotesPage() {
                   <Filter className="w-4 h-4 mr-2" />
                   Filtros
                 </Button>
-                <Button 
-                  onClick={() => setShowUpload(true)}
+                <Button
+                  onClick={() => router.push('/notes/upload')}
                   className="bg-purple-600 hover:bg-purple-700"
                 >
                   <Upload className="w-4 h-4 mr-2" />
@@ -176,19 +159,17 @@ export default function NotesPage() {
         />
       </div>
 
-      {/* Upload Modal */}
-      {showUpload && (
-        <NotesUpload 
-          onClose={() => setShowUpload(false)}
-          onSuccess={handleUploadSuccess}
-        />
-      )}
-
       {/* Viewer Modal */}
       {selectedNote && (
-        <NotesViewer 
+        <NotesViewer
           note={selectedNote}
+          isOpen={true}
           onClose={() => setSelectedNote(null)}
+          onLike={() => {}}
+          onDownload={() => {
+            const file = selectedNote.files[0];
+            if (file) window.open(file.url, '_blank');
+          }}
         />
       )}
     </div>

--- a/app/notes/upload/page.tsx
+++ b/app/notes/upload/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { NotesUpload } from '@/components/notes/NotesUpload';
+
+export default function NotesUploadPage() {
+  const router = useRouter();
+
+  const handleClose = () => router.push('/notes');
+  const handleSuccess = () => router.push('/notes');
+
+  return <NotesUpload open={true} onClose={handleClose} onSuccess={handleSuccess} />;
+}

--- a/components/notes/NotesGrid.tsx
+++ b/components/notes/NotesGrid.tsx
@@ -254,11 +254,26 @@ export function NotesGrid({ searchQuery, onNoteSelect }: NotesGridProps) {
             
             {/* Quick actions overlay */}
             <div className="absolute inset-0 bg-black/60 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex items-center justify-center gap-2">
-              <Button size="sm" className="bg-white text-gray-900 hover:bg-gray-100">
+              <Button
+                size="sm"
+                className="bg-white text-gray-900 hover:bg-gray-100"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onNoteSelect(note.id);
+                }}
+              >
                 <Eye className="w-4 h-4 mr-1" />
                 Ver
               </Button>
-              <Button size="sm" className="bg-purple-600 text-white hover:bg-purple-700">
+              <Button
+                size="sm"
+                className="bg-purple-600 text-white hover:bg-purple-700"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  const file = note.files[0];
+                  if (file) window.open(file.url, '_blank');
+                }}
+              >
                 <Download className="w-4 h-4 mr-1" />
                 Descargar
               </Button>

--- a/components/notes/NotesUpload.tsx
+++ b/components/notes/NotesUpload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -13,7 +13,9 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Upload, X, FileText, Image, Video, File, Plus } from 'lucide-react';
 
 interface NotesUploadProps {
-  onUpload: (noteData: any) => void;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: (noteData: any) => void;
 }
 
 const categories = [
@@ -61,8 +63,7 @@ const fileTypes = [
   { type: 'document', icon: File, label: 'Documento', accept: '.doc,.docx,.txt,.rtf' }
 ];
 
-export function NotesUpload({ onUpload }: NotesUploadProps) {
-  const [open, setOpen] = useState(false);
+export function NotesUpload({ open, onClose, onSuccess }: NotesUploadProps) {
   const [formData, setFormData] = useState({
     title: '',
     description: '',
@@ -96,8 +97,8 @@ export function NotesUpload({ onUpload }: NotesUploadProps) {
       liked: false
     };
     
-    onUpload(noteData);
-    setOpen(false);
+    onSuccess(noteData);
+    onClose();
     resetForm();
   };
 
@@ -180,13 +181,7 @@ export function NotesUpload({ onUpload }: NotesUploadProps) {
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
-        <Button className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700">
-          <Upload className="w-4 h-4 mr-2" />
-          Subir Apuntes
-        </Button>
-      </DialogTrigger>
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
@@ -389,11 +384,11 @@ export function NotesUpload({ onUpload }: NotesUploadProps) {
 
           {/* Submit Buttons */}
           <div className="flex justify-end gap-2 pt-4 border-t">
-            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+            <Button type="button" variant="outline" onClick={onClose}>
               Cancelar
             </Button>
-            <Button 
-              type="submit" 
+            <Button
+              type="submit"
               className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
               disabled={!formData.title || !formData.description || !formData.category || !formData.career || formData.files.length === 0}
             >


### PR DESCRIPTION
## Summary
- add `/notes/upload` route and use modal upload form
- enable view/download actions in notes grid
- open note viewer with basic download handler

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3df440fd08321b9dc0dbf141813f4