### PR TITLE
Redirect root routes to default pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Redirect root `auth`, `admin`, and `profile` paths to their default pages to eliminate 404 errors.
 - Fix unbalanced braces and missing imports in comments API, notes page, feed pages, and forum icons so `npm run build` and development server start successfully.
 - Add `/notes/upload` route and convert upload form to modal to avoid duplicate "Subir Apunte" buttons.
 - Wire "Ver" and "Descargar" actions in notes grid to open the viewer and download the first file.

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+export default function AdminIndexPage() {
+  redirect('/admin/gamification')
+}
+

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+export default function AuthIndexPage() {
+  redirect('/auth/login')
+}
+

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation'
+
+export default function ProfileIndexPage() {
+  redirect('/perfil')
+}
+


### PR DESCRIPTION
## Summary
- redirect `/admin` to gamification dashboard
- forward `/profile` to `/perfil`
- send `/auth` visitors to `/auth/login`

## Testing
- `npm run lint`
- `curl -I http://localhost:3000/admin`
- `curl -I http://localhost:3000/profile`
- `curl -I http://localhost:3000/auth`


------
https://chatgpt.com/codex/tasks/task_e_68b400dc9a74832186a2bee131a85ea4