### PR TITLE
fix: reemplazar valores vacíos en SelectItem

### DIFF
--- a/app/clubs/create/page.tsx
+++ b/app/clubs/create/page.tsx
@@ -101,7 +101,12 @@ export default function CreateClubPage() {
 
   const validateForm = (): boolean => {
     try {
-      createClubSchema.parse(formData);
+      const sanitizedData = {
+        ...formData,
+        subject: formData.subject === 'none' ? undefined : formData.subject,
+        level: formData.level === 'none' ? undefined : formData.level,
+      };
+      createClubSchema.parse(sanitizedData);
       setErrors({});
       return true;
     } catch (error) {
@@ -134,12 +139,18 @@ export default function CreateClubPage() {
     try {
       setLoading(true);
       
+      const payload = {
+        ...formData,
+        subject: formData.subject === 'none' ? undefined : formData.subject,
+        level: formData.level === 'none' ? undefined : formData.level,
+      };
+
       const response = await fetch('/api/clubs', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(formData),
+        body: JSON.stringify(payload),
       });
 
       if (!response.ok) {
@@ -270,7 +281,7 @@ export default function CreateClubPage() {
                         <SelectValue placeholder="Selecciona una materia" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="">Ninguna</SelectItem>
+                        <SelectItem value="none">Ninguna</SelectItem>
                         {subjects.map((subject) => (
                           <SelectItem key={subject} value={subject}>
                             {subject}
@@ -287,7 +298,7 @@ export default function CreateClubPage() {
                         <SelectValue placeholder="Selecciona un nivel" />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="">Ninguno</SelectItem>
+                        <SelectItem value="none">Ninguno</SelectItem>
                         {levels.map((level) => (
                           <SelectItem key={level} value={level}>
                             {level}

--- a/app/clubs/page.tsx
+++ b/app/clubs/page.tsx
@@ -50,8 +50,8 @@ export default function ClubsPage() {
   const [activeTab, setActiveTab] = useState("browse");
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedCategory, setSelectedCategory] = useState("Todas");
-  const [selectedSubject, setSelectedSubject] = useState("");
-  const [selectedLevel, setSelectedLevel] = useState("");
+  const [selectedSubject, setSelectedSubject] = useState("Todas");
+  const [selectedLevel, setSelectedLevel] = useState("ALL");
   const [sortBy, setSortBy] = useState("recent");
   const [selectedClubId, setSelectedClubId] = useState<string | null>(null);
   const [creatingClub, setCreatingClub] = useState(false);
@@ -78,7 +78,7 @@ export default function ClubsPage() {
   ];
   
   const levelOptions = [
-    { value: "", label: "Todos los niveles" },
+    { value: "ALL", label: "Todos los niveles" },
     { value: "BEGINNER", label: "Principiante" },
     { value: "INTERMEDIATE", label: "Intermedio" },
     { value: "ADVANCED", label: "Avanzado" }
@@ -93,8 +93,8 @@ export default function ClubsPage() {
         limit: '12',
         ...(searchQuery && { search: searchQuery }),
         ...(selectedCategory !== 'Todas' && { category: selectedCategory }),
-        ...(selectedSubject && { subject: selectedSubject }),
-        ...(selectedLevel && { level: selectedLevel }),
+        ...(selectedSubject !== 'Todas' && { subject: selectedSubject }),
+        ...(selectedLevel !== 'ALL' && { level: selectedLevel }),
         ...(sortBy && { sortBy })
       });
       
@@ -335,7 +335,7 @@ export default function ClubsPage() {
                       <SelectValue placeholder="Materia" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="">Todas las materias</SelectItem>
+                      <SelectItem value="Todas">Todas las materias</SelectItem>
                       {subjects.map(subject => (
                         <SelectItem key={subject} value={subject}>{subject}</SelectItem>
                       ))}

--- a/components/admin/AchievementModal.tsx
+++ b/components/admin/AchievementModal.tsx
@@ -370,15 +370,17 @@ export function AchievementModal({ isOpen, onClose, onSave, achievement, mode, b
           {/* Badge asociado */}
           <div className="space-y-2">
             <Label htmlFor="badgeId">Badge Asociado (Opcional)</Label>
-            <Select 
-              value={formData.badgeId || ''} 
-              onValueChange={(value) => handleChange('badgeId', value || undefined)}
+            <Select
+              value={formData.badgeId ?? ''}
+              onValueChange={(value) =>
+                handleChange('badgeId', value === 'none' ? undefined : value)
+              }
             >
               <SelectTrigger>
                 <SelectValue placeholder="Seleccionar badge (opcional)" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="">Sin badge asociado</SelectItem>
+                <SelectItem value="none">Sin badge asociado</SelectItem>
                 {badges.map(badge => (
                   <SelectItem key={badge.id} value={badge.id}>
                     <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- evita valores vacíos en SelectItem para filtros de clubs y creación de clubes
- sanea campos opcionales antes de enviarlos al backend
- ajusta selector de logro para admitir opción "Sin badge asociado"

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4aca7fb748321abcdc2fa1cc853ce