### PR TITLE
fix: align club sort options with API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Align club page sort options with API parameters and compute pagination to prevent fetch errors.
 - Redirect root `auth`, `admin`, and `profile` paths to their default pages to eliminate 404 errors.
 - Fix unbalanced braces and missing imports in comments API, notes page, feed pages, and forum icons so `npm run build` and development server start successfully.
 - Add `/notes/upload` route and convert upload form to modal to avoid duplicate "Subir Apunte" buttons.


### PR DESCRIPTION
## Summary
- map client sort options to API fields and calculate pagination
- handle my clubs count from stats and improve error handling
- document club fetch fix in changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c2c16d2883218e5eac573a6e00b5