### PR TITLE
Guard club rating display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Guard club rating display to avoid runtime errors when rating is missing.
 - Align club page sort options with API parameters and compute pagination to prevent fetch errors.
 - Redirect root `auth`, `admin`, and `profile` paths to their default pages to eliminate 404 errors.
 - Fix unbalanced braces and missing imports in comments API, notes page, feed pages, and forum icons so `npm run build` and development server start successfully.

--- a/components/clubs/ClubCard.tsx
+++ b/components/clubs/ClubCard.tsx
@@ -71,13 +71,14 @@ export default function ClubCard({
     return colors[category] || 'bg-gray-100 text-gray-800';
   };
 
-  const renderStars = (rating: number) => {
+  const renderStars = (rating?: number) => {
+    const safeRating = rating ?? 0;
     return Array.from({ length: 5 }, (_, i) => (
       <Star
         key={i}
         className={`h-4 w-4 ${
-          i < Math.floor(rating) 
-            ? 'text-yellow-400 fill-current' 
+          i < Math.floor(safeRating)
+            ? 'text-yellow-400 fill-current'
             : 'text-gray-300'
         }`}
       />
@@ -130,7 +131,7 @@ export default function ClubCard({
           <div className="flex items-center gap-1">
             {renderStars(club.rating)}
             <span className="text-sm text-gray-600 ml-1">
-              ({club.rating.toFixed(1)})
+              ({club.rating !== undefined ? club.rating.toFixed(1) : 'N/A'})
             </span>
           </div>
         </div>

--- a/components/clubs/ClubDetail.tsx
+++ b/components/clubs/ClubDetail.tsx
@@ -131,13 +131,14 @@ export default function ClubDetail({
     return colors[category] || 'bg-gray-100 text-gray-800';
   };
 
-  const renderStars = (rating: number) => {
+  const renderStars = (rating?: number) => {
+    const safeRating = rating ?? 0;
     return Array.from({ length: 5 }, (_, i) => (
       <Star
         key={i}
         className={`h-4 w-4 ${
-          i < Math.floor(rating) 
-            ? 'text-yellow-400 fill-current' 
+          i < Math.floor(safeRating)
+            ? 'text-yellow-400 fill-current'
             : 'text-gray-300'
         }`}
       />
@@ -209,7 +210,7 @@ export default function ClubDetail({
                     <div className="flex items-center gap-1">
                       {renderStars(club.rating)}
                       <span className="text-sm text-gray-600 ml-1">
-                        ({club.rating.toFixed(1)})
+                        ({club.rating !== undefined ? club.rating.toFixed(1) : 'N/A'})
                       </span>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- avoid undefined rating errors by guarding club rating in cards and detail
- document club rating guard in changelog

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c4521e5083218026e4db4298e57c