### PR TITLE
fix: guard club president data and optional activity query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Guard club president access and details when data is missing to avoid runtime errors.
+- Allow optional `includeActivity` parameter in `/api/clubs/my-clubs` to prevent validation failures when omitted.
 - Prevent redundant notification fetches and SSE reconnections by refining `useNotifications` dependencies.
 - Guard club rating display to avoid runtime errors when rating is missing.
 - Align club page sort options with API parameters and compute pagination to prevent fetch errors.

--- a/app/api/clubs/my-clubs/route.ts
+++ b/app/api/clubs/my-clubs/route.ts
@@ -5,8 +5,8 @@ import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 
 const querySchema = z.object({
-  includeStats: z.string().optional().transform(val => val === 'true'),
-  includeActivity: z.string().optional().transform(val => val === 'true'),
+  includeStats: z.string().nullish().transform(val => val === 'true'),
+  includeActivity: z.string().nullish().transform(val => val === 'true'),
 });
 
 export async function GET(request: NextRequest) {

--- a/components/clubs/ClubCard.tsx
+++ b/components/clubs/ClubCard.tsx
@@ -160,13 +160,20 @@ export default function ClubCard({
         {/* Presidente del Club */}
         <div className="flex items-center gap-3 p-3 bg-gray-50 rounded-lg">
           <Avatar className="h-8 w-8">
-            <AvatarImage src={club.president.avatar} />
+            <AvatarImage src={club.president?.avatar ?? undefined} />
             <AvatarFallback>
-              {club.president.name.split(' ').map(n => n[0]).join('')}
+              {club.president?.name
+                ? club.president.name
+                    .split(' ')
+                    .map(n => n[0])
+                    .join('')
+                : 'NA'}
             </AvatarFallback>
           </Avatar>
           <div>
-            <p className="text-sm font-medium">{club.president.name}</p>
+            <p className="text-sm font-medium">
+              {club.president?.name ?? 'Presidente no asignado'}
+            </p>
             <p className="text-xs text-gray-500">Presidente</p>
           </div>
         </div>

--- a/components/clubs/ClubDetail.tsx
+++ b/components/clubs/ClubDetail.tsx
@@ -378,15 +378,22 @@ export default function ClubDetail({
             <CardContent>
               <div className="flex items-center gap-4 p-4 bg-blue-50 rounded-lg">
                 <Avatar className="h-12 w-12">
-                  <AvatarImage src={club.president.avatar} />
+                  <AvatarImage src={club.president?.avatar ?? undefined} />
                   <AvatarFallback>
-                    {club.president.name.split(' ').map(n => n[0]).join('')}
+                    {club.president?.name
+                      ? club.president.name
+                          .split(' ')
+                          .map(n => n[0])
+                          .join('')
+                      : 'NA'}
                   </AvatarFallback>
                 </Avatar>
                 <div className="flex-1">
-                  <h4 className="font-semibold">{club.president.name}</h4>
+                  <h4 className="font-semibold">
+                    {club.president?.name ?? 'Presidente no asignado'}
+                  </h4>
                   <p className="text-sm text-gray-600">Presidente</p>
-                  {club.president.email && (
+                  {club.president?.email && (
                     <p className="text-sm text-blue-600">{club.president.email}</p>
                   )}
                 </div>


### PR DESCRIPTION
## Summary
- handle missing club president data in cards and detail view
- allow optional includeActivity in my clubs API
- document fixes in changelog

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7ac272c8321b756d9a99f184d99