### PR TITLE
feat: add app error boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add global error boundary to log errors and offer reload or home navigation.
+
 - Prevent redundant notification fetches and SSE reconnections by refining `useNotifications` dependencies.
 - Guard club rating display to avoid runtime errors when rating is missing.
 - Align club page sort options with API parameters and compute pagination to prevent fetch errors.

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[50vh] gap-4">
+      <h2 className="text-2xl font-semibold">Algo salió mal</h2>
+      <div className="flex gap-4">
+        <button
+          onClick={() => reset()}
+          className="rounded bg-violet-600 px-4 py-2 text-white"
+        >
+          Recargar
+        </button>
+        <Link
+          href="/"
+          className="rounded border px-4 py-2"
+        >
+          Inicio
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,3 +37,5 @@ export default function RootLayout({
     </html>
   );
 }
+
+export { default as ErrorBoundary } from "./error";


### PR DESCRIPTION
## Summary
- add global error boundary component that logs errors and offers home or reload buttons
- export error boundary from layout
- document new error boundary in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c7e73f1083218d4454d00c884747