### PR TITLE
fix: normalize club tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add global error boundary to log errors and offer reload or home navigation.
 - Guard club president access and details when data is missing to avoid runtime errors.
 - Allow optional `includeActivity` parameter in `/api/clubs/my-clubs` to prevent validation failures when omitted.
+- Normalize club tag data to handle strings and prevent `slice(...).map` runtime errors in club cards and detail views.
 - Prevent redundant notification fetches and SSE reconnections by refining `useNotifications` dependencies.
 - Maintain a stable notifications stream by storing the `EventSource` in a ref and avoiding duplicate connections.
 - Guard club rating display to avoid runtime errors when rating is missing.

--- a/components/clubs/ClubCard.tsx
+++ b/components/clubs/ClubCard.tsx
@@ -17,7 +17,7 @@ interface Club {
   meetingDay: string;
   rating: number;
   image?: string;
-  tags: string[];
+  tags: string[] | string;
   isJoined: boolean;
   isFavorite: boolean;
   president: {
@@ -42,8 +42,8 @@ export default function ClubCard({
   club, 
   onJoin, 
   onLeave, 
-  onFavorite, 
-  onViewDetails 
+  onFavorite,
+  onViewDetails
 }: ClubCardProps) {
   const handleJoinLeave = () => {
     if (club.isJoined) {
@@ -56,6 +56,13 @@ export default function ClubCard({
   const handleFavorite = () => {
     onFavorite?.(club.id);
   };
+
+  // Ensure tags are always handled as an array
+  const tags = Array.isArray(club.tags)
+    ? club.tags
+    : typeof club.tags === 'string'
+      ? club.tags.split(',').map(tag => tag.trim())
+      : [];
 
   const getCategoryColor = (category: string) => {
     const colors: { [key: string]: string } = {
@@ -198,16 +205,16 @@ export default function ClubCard({
         )}
 
         {/* Tags */}
-        {club.tags.length > 0 && (
+        {tags.length > 0 && (
           <div className="flex flex-wrap gap-1">
-            {club.tags.slice(0, 3).map((tag) => (
+            {tags.slice(0, 3).map((tag) => (
               <Badge key={tag} variant="outline" className="text-xs">
                 {tag}
               </Badge>
             ))}
-            {club.tags.length > 3 && (
+            {tags.length > 3 && (
               <Badge variant="outline" className="text-xs">
-                +{club.tags.length - 3} más
+                +{tags.length - 3} más
               </Badge>
             )}
           </div>

--- a/components/clubs/ClubDetail.tsx
+++ b/components/clubs/ClubDetail.tsx
@@ -64,7 +64,7 @@ interface Club {
   rating: number;
   image?: string;
   coverImage?: string;
-  tags: string[];
+  tags: string[] | string;
   isJoined: boolean;
   isFavorite: boolean;
   foundedDate: string;
@@ -100,8 +100,8 @@ export default function ClubDetail({
   club, 
   onJoin, 
   onLeave, 
-  onFavorite, 
-  onClose 
+  onFavorite,
+  onClose
 }: ClubDetailProps) {
   const [activeTab, setActiveTab] = useState('overview');
 
@@ -116,6 +116,13 @@ export default function ClubDetail({
   const handleFavorite = () => {
     onFavorite?.(club.id);
   };
+
+  // Normalize tags to always work with an array
+  const tags = Array.isArray(club.tags)
+    ? club.tags
+    : typeof club.tags === 'string'
+      ? club.tags.split(',').map(tag => tag.trim())
+      : [];
 
   const getCategoryColor = (category: string) => {
     const colors: { [key: string]: string } = {
@@ -353,11 +360,11 @@ export default function ClubDetail({
                 </div>
               </div>
               
-              {club.tags.length > 0 && (
+              {tags.length > 0 && (
                 <div>
                   <h4 className="font-semibold mb-3">Etiquetas</h4>
                   <div className="flex flex-wrap gap-2">
-                    {club.tags.map((tag) => (
+                    {tags.map((tag) => (
                       <Badge key={tag} variant="outline">
                         {tag}
                       </Badge>

--- a/src/components/clubs/ClubCard.tsx
+++ b/src/components/clubs/ClubCard.tsx
@@ -33,7 +33,7 @@ interface Club {
     avatar: string;
     role: string;
   };
-  tags: string[];
+  tags: string[] | string;
   level: string;
   createdAt: string;
   lastActivity: string;
@@ -82,6 +82,13 @@ export function ClubCard({ club, onClick }: ClubCardProps) {
       console.error('Error granting XP for joining club:', error);
     }
   };
+
+  // Ensure tags are treated as an array
+  const tags = Array.isArray(club.tags)
+    ? club.tags
+    : typeof club.tags === 'string'
+      ? club.tags.split(',').map(tag => tag.trim())
+      : [];
 
   const getCategoryColor = (category: string) => {
     switch (category) {
@@ -207,14 +214,14 @@ export function ClubCard({ club, onClick }: ClubCardProps) {
 
         {/* Tags */}
         <div className="flex flex-wrap gap-1">
-          {club.tags.slice(0, 3).map((tag, index) => (
+          {tags.slice(0, 3).map((tag, index) => (
             <Badge key={index} variant="outline" className="text-xs bg-gray-50">
               {tag}
             </Badge>
           ))}
-          {club.tags.length > 3 && (
+          {tags.length > 3 && (
             <Badge variant="outline" className="text-xs bg-gray-50">
-              +{club.tags.length - 3}
+              +{tags.length - 3}
             </Badge>
           )}
         </div>

--- a/src/components/clubs/ClubDetail.tsx
+++ b/src/components/clubs/ClubDetail.tsx
@@ -42,7 +42,7 @@ interface Club {
     avatar: string;
     role: string;
   };
-  tags: string[];
+  tags: string[] | string;
   level: string;
   createdAt: string;
   lastActivity: string;
@@ -158,6 +158,13 @@ export function ClubDetail({ club, onBack }: ClubDetailProps) {
       setNewPost("");
     }
   };
+
+  // Normalize tags to always work with an array
+  const tags = Array.isArray(club.tags)
+    ? club.tags
+    : typeof club.tags === 'string'
+      ? club.tags.split(',').map(tag => tag.trim())
+      : [];
 
   const getCategoryColor = (category: string) => {
     switch (category) {
@@ -297,7 +304,7 @@ export function ClubDetail({ club, onBack }: ClubDetailProps) {
 
             {/* Tags */}
             <div className="flex flex-wrap gap-2 mt-4">
-              {club.tags.map((tag, index) => (
+              {tags.map((tag, index) => (
                 <Badge key={index} variant="outline" className="bg-gray-50">
                   {tag}
                 </Badge>

--- a/src/components/clubs/MyClubs.tsx
+++ b/src/components/clubs/MyClubs.tsx
@@ -37,7 +37,7 @@ interface Club {
     avatar: string;
     role: string;
   };
-  tags: string[];
+  tags: string[] | string;
   level: string;
   createdAt: string;
   lastActivity: string;
@@ -157,11 +157,16 @@ export function MyClubs({ onClubSelect }: MyClubsProps) {
   const [categoryFilter, setCategoryFilter] = useState("all");
   const [sortBy, setSortBy] = useState("recent");
 
+  const normalizeTags = (tags: string[] | string) =>
+    Array.isArray(tags) ? tags : tags.split(',').map(tag => tag.trim());
+
   const filteredClubs = mockMyClubs
     .filter(club => {
-      const matchesSearch = club.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                           club.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                           club.tags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()));
+      const clubTags = normalizeTags(club.tags);
+      const matchesSearch =
+        club.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        club.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        clubTags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()));
       
       const matchesRole = roleFilter === "all" || club.role === roleFilter;
       const matchesCategory = categoryFilter === "all" || club.category === categoryFilter;
@@ -421,18 +426,23 @@ export function MyClubs({ onClubSelect }: MyClubsProps) {
               </div>
 
               {/* Tags */}
-              <div className="flex flex-wrap gap-1 mb-3">
-                {club.tags.slice(0, 3).map((tag, index) => (
-                  <Badge key={index} variant="outline" className="text-xs bg-gray-50">
-                    {tag}
-                  </Badge>
-                ))}
-                {club.tags.length > 3 && (
-                  <Badge variant="outline" className="text-xs bg-gray-50">
-                    +{club.tags.length - 3}
-                  </Badge>
-                )}
-              </div>
+              {(() => {
+                const clubTags = normalizeTags(club.tags);
+                return (
+                  <div className="flex flex-wrap gap-1 mb-3">
+                    {clubTags.slice(0, 3).map((tag, index) => (
+                      <Badge key={index} variant="outline" className="text-xs bg-gray-50">
+                        {tag}
+                      </Badge>
+                    ))}
+                    {clubTags.length > 3 && (
+                      <Badge variant="outline" className="text-xs bg-gray-50">
+                        +{clubTags.length - 3}
+                      </Badge>
+                    )}
+                  </div>
+                );
+              })()}
 
               {/* Actions */}
               <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- guard club components against tag strings to prevent runtime errors
- document tag normalization in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c9ff52708321b4d6de84d868efbe