### PR TITLE
feat: add debug fetch wrapper for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Wrap notifications API calls with a development debug fetch that counts usage.
 - Add global error boundary to log errors and offer reload or home navigation.
 - Guard club president access and details when data is missing to avoid runtime errors.
 - Allow optional `includeActivity` parameter in `/api/clubs/my-clubs` to prevent validation failures when omitted.

--- a/hooks/useNotifications.ts
+++ b/hooks/useNotifications.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
+import { debugFetch } from '@/lib/debugFetch';
 
 interface Notification {
   id: string;
@@ -55,7 +56,7 @@ export function useNotifications(): UseNotificationsReturn {
     setError(null);
 
     try {
-      const response = await fetch(`/api/notifications?page=${pageNum}&limit=20`);
+      const response = await debugFetch(`/api/notifications?page=${pageNum}&limit=20`);
       
       if (!response.ok) {
         throw new Error('Error al cargar notificaciones');
@@ -89,7 +90,7 @@ export function useNotifications(): UseNotificationsReturn {
   // Marcar notificación como leída
   const markAsRead = useCallback(async (notificationId: string) => {
     try {
-      const response = await fetch('/api/notifications', {
+      const response = await debugFetch('/api/notifications', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ notificationIds: [notificationId] })
@@ -117,7 +118,7 @@ export function useNotifications(): UseNotificationsReturn {
   // Marcar todas como leídas
   const markAllAsRead = useCallback(async () => {
     try {
-      const response = await fetch('/api/notifications', {
+      const response = await debugFetch('/api/notifications', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ markAllAsRead: true })
@@ -141,7 +142,7 @@ export function useNotifications(): UseNotificationsReturn {
   // Eliminar notificación
   const deleteNotification = useCallback(async (notificationId: string) => {
     try {
-      const response = await fetch(`/api/notifications?ids=${notificationId}`, {
+      const response = await debugFetch(`/api/notifications?ids=${notificationId}`, {
         method: 'DELETE'
       });
 
@@ -167,7 +168,7 @@ export function useNotifications(): UseNotificationsReturn {
   // Limpiar todas las notificaciones
   const clearAll = useCallback(async () => {
     try {
-      const response = await fetch('/api/notifications?all=true', {
+      const response = await debugFetch('/api/notifications?all=true', {
         method: 'DELETE'
       });
 
@@ -303,7 +304,7 @@ export function useUnreadNotificationCount() {
 
     setIsLoading(true);
     try {
-      const response = await fetch('/api/notifications?limit=1&unreadOnly=true');
+      const response = await debugFetch('/api/notifications?limit=1&unreadOnly=true');
       if (response.ok) {
         const data = await response.json();
         setUnreadCount(data.unreadCount);

--- a/lib/debugFetch.ts
+++ b/lib/debugFetch.ts
@@ -1,0 +1,10 @@
+// Logs notification API requests in development while delegating to the native fetch.
+export function debugFetch(input: RequestInfo | URL, init?: RequestInit) {
+  if (process.env.NODE_ENV !== 'production') {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : '';
+    if (url.includes('/api/notifications')) {
+      console.count('fetch /api/notifications');
+    }
+  }
+  return fetch(input, init);
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
+import { debugFetch } from '@/lib/debugFetch';
 
 export interface Notification {
   id: string;
@@ -36,7 +37,7 @@ export function useNotifications(): UseNotificationsReturn {
     if (!session?.user?.id) return;
 
     try {
-      const response = await fetch('/api/notifications');
+      const response = await debugFetch('/api/notifications');
       if (response.ok) {
         const data = await response.json();
         setNotifications(data.notifications || []);
@@ -52,7 +53,7 @@ export function useNotifications(): UseNotificationsReturn {
     if (!session?.user?.id) return;
 
     try {
-      const response = await fetch(`/api/notifications/${notificationId}/read`, {
+      const response = await debugFetch(`/api/notifications/${notificationId}/read`, {
         method: 'PATCH'
       });
 
@@ -76,7 +77,7 @@ export function useNotifications(): UseNotificationsReturn {
     if (!session?.user?.id) return;
 
     try {
-      const response = await fetch('/api/notifications/read-all', {
+      const response = await debugFetch('/api/notifications/read-all', {
         method: 'PATCH'
       });
 
@@ -217,7 +218,7 @@ export function useNotificationPreferences() {
     if (!session?.user?.id) return;
 
     try {
-      const response = await fetch('/api/notifications/preferences');
+      const response = await debugFetch('/api/notifications/preferences');
       if (response.ok) {
         const data = await response.json();
         setPreferences(data);
@@ -232,7 +233,7 @@ export function useNotificationPreferences() {
     if (!session?.user?.id) return;
 
     try {
-      const response = await fetch('/api/notifications/preferences', {
+      const response = await debugFetch('/api/notifications/preferences', {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- log notification API calls in development via debug fetch wrapper
- refactor notification hooks to use debug fetch
- document debug fetch in changelog

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4cc459944832191924043604d3664