### PR TITLE
fix: export marketplace components as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Replace Notes viewer modal with previous implementation to support PDF and image preview.
 - Correct footer links for Cookies, Privacy, Terms, and Support pages.
 - Allow unauthenticated users to view public posts via the feed API.
+- Fix missing default exports in marketplace components to prevent invalid element type errors.
 - Resolve feed API route type mismatches and enum casing errors.
 - Skip notification stream setup when unauthenticated to eliminate 401 errors.
 - Gracefully return an empty feed when the database is unavailable.

--- a/components/marketplace/CategoryFilter.tsx
+++ b/components/marketplace/CategoryFilter.tsx
@@ -11,7 +11,9 @@ interface Category {
   name: string;
   parentId?: string;
   children?: Category[];
-}
+  }
+
+export default CategoryFilter;
 
 interface CategoryFilterProps {
   categories: Category[];
@@ -108,3 +110,4 @@ export function CategoryFilter({ categories, selectedCategory, onCategorySelect 
     </Card>
   );
 }
+export default CategoryFilter;

--- a/components/marketplace/MarketplaceStats.tsx
+++ b/components/marketplace/MarketplaceStats.tsx
@@ -186,3 +186,5 @@ export function MarketplaceStats({
     </div>
   );
 }
+
+export default MarketplaceStats;

--- a/components/marketplace/ShoppingCart.tsx
+++ b/components/marketplace/ShoppingCart.tsx
@@ -218,3 +218,5 @@ export function ShoppingCart({
     </div>
   );
 }
+
+export default ShoppingCart;


### PR DESCRIPTION
## Summary
- export CategoryFilter as default
- export MarketplaceStats as default
- export ShoppingCart as default
- document fixes in changelog

## Testing
- `npm test`
- `npm run lint` (warnings)

------
https://chatgpt.com/codex/tasks/task_e_68b4f63582188321a8d3864ca04e884f