### PR TITLE
fix: remove duplicate default export in CategoryFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Fix duplicate default export in `CategoryFilter` component that caused Next.js build failures.
+
 - Add user stats and trending topics API endpoints to resolve profile and feed 404 errors.
 - Provide default and placeholder avatars to eliminate broken image requests.
 - Handle profile loading failures gracefully and display an error message instead of an endless spinner.

--- a/components/marketplace/CategoryFilter.tsx
+++ b/components/marketplace/CategoryFilter.tsx
@@ -11,9 +11,7 @@ interface Category {
   name: string;
   parentId?: string;
   children?: Category[];
-  }
-
-export default CategoryFilter;
+}
 
 interface CategoryFilterProps {
   categories: Category[];
@@ -21,7 +19,7 @@ interface CategoryFilterProps {
   onCategorySelect: (categoryId: string | undefined) => void;
 }
 
-export function CategoryFilter({ categories, selectedCategory, onCategorySelect }: CategoryFilterProps) {
+export default function CategoryFilter({ categories, selectedCategory, onCategorySelect }: CategoryFilterProps) {
   const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
 
   const toggleExpanded = (categoryId: string) => {
@@ -110,4 +108,3 @@ export function CategoryFilter({ categories, selectedCategory, onCategorySelect 
     </Card>
   );
 }
-export default CategoryFilter;


### PR DESCRIPTION
## Summary
- remove stray default export and convert CategoryFilter to a single default function
- document CategoryFilter export fix in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5085de520832181faef6c9e6ac79f