### PR TITLE
Fix duplicate default export in CategoryFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix duplicate default export in `CategoryFilter` to resolve Next.js build error.
 - Add user stats and trending topics API endpoints to resolve profile and feed 404 errors.
 - Provide default and placeholder avatars to eliminate broken image requests.
 - Handle profile loading failures gracefully and display an error message instead of an endless spinner.

--- a/components/marketplace/CategoryFilter.tsx
+++ b/components/marketplace/CategoryFilter.tsx
@@ -13,8 +13,6 @@ interface Category {
   children?: Category[];
   }
 
-export default CategoryFilter;
-
 interface CategoryFilterProps {
   categories: Category[];
   selectedCategory?: string;


### PR DESCRIPTION
## Summary
- remove stray default export in CategoryFilter to fix Next.js build error
- document fix in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5085de520832181faef6c9e6ac79f