### PR TITLE
fix: resolve build errors in auth and marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@
 - Correct footer links for Cookies, Privacy, Terms, and Support pages.
 - Allow unauthenticated users to view public posts via the feed API.
 - Fix missing default exports in marketplace components to prevent invalid element type errors.
+- Import auth options from shared `@/lib/auth` in club management API route to resolve build-time export errors.
+- Pass detailed cart items and use the named `ShoppingCart` export in the marketplace page to avoid `reduce` on undefined during prerendering.
 - Resolve feed API route type mismatches and enum casing errors.
 - Skip notification stream setup when unauthenticated to eliminate 401 errors.
 - Gracefully return an empty feed when the database is unavailable.

--- a/app/api/clubs/[id]/manage/route.ts
+++ b/app/api/clubs/[id]/manage/route.ts
@@ -1,6 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
-import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+// Use shared auth options directly from the lib folder instead of importing
+// from the NextAuth route, which doesn't re-export them. This prevents build
+// errors when compiling API routes.
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -22,7 +22,9 @@ import ProductDetail from '@/components/marketplace/ProductDetail';
 import SellProductModal from '@/components/marketplace/SellProductModal';
 import CategoryFilter from '@/components/marketplace/CategoryFilter';
 import MarketplaceStats from '@/components/marketplace/MarketplaceStats';
-import ShoppingCartComponent from '@/components/marketplace/ShoppingCart';
+// Import ShoppingCart as a named export to ensure the component is defined
+// correctly when rendered in the page.
+import { ShoppingCart as ShoppingCartComponent } from '@/components/marketplace/ShoppingCart';
 
 // Mock data para productos del marketplace
 const mockProducts = [
@@ -299,6 +301,36 @@ export default function MarketplacePage() {
     // Aquí se implementaría la lógica de checkout
   };
 
+  // Transform simple cart items into detailed items expected by ShoppingCart
+  // component by merging with product information.
+  const cartItemsDetailed = cartItems
+    .map((item) => {
+      const product = mockProducts.find((p) => p.id === item.id);
+      if (!product) return null;
+      return {
+        id: item.id,
+        productId: product.id,
+        productName: product.name,
+        productImage: product.images[0],
+        price: product.price,
+        priceInSoles: product.priceInSoles,
+        quantity: item.quantity,
+        stock: product.stock,
+        seller: product.seller,
+      };
+    })
+    .filter(Boolean) as Array<{
+      id: string;
+      productId: string;
+      productName: string;
+      productImage: string;
+      price: number;
+      priceInSoles: number;
+      quantity: number;
+      stock: number;
+      seller: { id: string; name: string; avatar?: string };
+    }>;
+
   // Si hay un producto seleccionado, mostrar ProductDetail
   if (selectedProductId) {
     const selectedProduct = mockProducts.find(p => p.id === selectedProductId);
@@ -539,7 +571,7 @@ export default function MarketplacePage() {
       <ShoppingCartComponent
         isOpen={showCart}
         onClose={() => setShowCart(false)}
-        cartItems={cartItems}
+        items={cartItemsDetailed}
         onUpdateQuantity={updateCartQuantity}
         onRemoveItem={removeFromCart}
         onCheckout={handleCheckout}


### PR DESCRIPTION
## Summary
- use shared auth options in club management API route to avoid missing export
- pass detailed cart items and import ShoppingCart properly in marketplace page
- document fixes in changelog

## Testing
- `npm run build`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b50a6a20908321989b595081050756