### PR TITLE
Hide sidebar on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix duplicate default export in `CategoryFilter` component that caused Next.js build failures.
 
+- Hide main sidebar on mobile so it only appears on desktop.
+
 - Add user stats and trending topics API endpoints to resolve profile and feed 404 errors.
 - Provide default and placeholder avatars to eliminate broken image requests.
 - Handle profile loading failures gracefully and display an error message instead of an endless spinner.

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -125,9 +125,9 @@ export function Sidebar() {
   };
 
   return (
-    <aside 
+    <aside
       className={cn(
-        'sticky top-16 h-[calc(100vh-4rem)] bg-white border-r border-crunevo-200 transition-all duration-300 overflow-y-auto',
+        'hidden md:block sticky top-16 h-[calc(100vh-4rem)] bg-white border-r border-crunevo-200 transition-all duration-300 overflow-y-auto',
         isCollapsed ? 'w-16' : 'w-64'
       )}
     >


### PR DESCRIPTION
## Summary
- ensure main sidebar only appears on desktop by hiding it on mobile
- document sidebar change in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b51c48ec9c832197a8f3fe4686ea14