### PR TITLE
Fix feed composer modal labels and close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fix undefined composer and redundant close button in feed; simplify quick action labels.
 - Fix duplicate default export in `CategoryFilter` component that caused Next.js build failures.
 - Hide main sidebar on mobile screens so it only appears on desktop.
 - Simplify feed layout by removing the left column, widening the timeline, adding a closable weekly challenge banner, and moving the user level card to the global sidebar.

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -80,7 +80,7 @@ export default function FeedPage() {
           <section className="lg:col-span-8 space-y-4">
             {session && (
               <Suspense fallback={<ComposerSkeleton />}>
-                <Composer />
+                <FacebookStyleComposer />
               </Suspense>
             )}
             <WeeklyChallengeInline />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
-import { FacebookStyleComposer } from '@/components/feed/FacebookStyleComposer';
 export default async function HomePage() {
   const session = await getServerSession(authOptions);
   if (!session) {

--- a/components/feed/FacebookStyleComposer.tsx
+++ b/components/feed/FacebookStyleComposer.tsx
@@ -7,11 +7,10 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Avatar } from '@/components/ui/avatar';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { 
-  ImageIcon, 
-  FileTextIcon, 
-  SmileIcon, 
-  X, 
+import {
+  ImageIcon,
+  FileTextIcon,
+  SmileIcon,
   Camera,
   BookOpen,
   HelpCircle
@@ -93,8 +92,8 @@ export function FacebookStyleComposer() {
         
         {/* Botones de opciones rápidas */}
         <div className="flex justify-between mt-3 pt-3 border-t border-gray-200">
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             className="flex-1 text-gray-600 hover:bg-gray-100"
             onClick={() => {
               setPostType('note');
@@ -102,10 +101,10 @@ export function FacebookStyleComposer() {
             }}
           >
             <BookOpen className="h-4 w-4 mr-2" />
-            Publicar un Apunte 📘
+            Apunte 📘
           </Button>
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             className="flex-1 text-gray-600 hover:bg-gray-100"
             onClick={() => {
               setPostType('question');
@@ -113,32 +112,30 @@ export function FacebookStyleComposer() {
             }}
           >
             <HelpCircle className="h-4 w-4 mr-2" />
-            Publicar una Pregunta ❓
+            Pregunta ❓
           </Button>
-          <Button 
-            variant="ghost" 
+          <Button
+            variant="ghost"
             className="flex-1 text-gray-600 hover:bg-gray-100"
             onClick={openModal}
           >
             <Camera className="h-4 w-4 mr-2" />
-            Publicar Foto/Video 🖼️
+            Foto/Video 🖼️
           </Button>
         </div>
       </Card>
 
       {/* Modal de creación */}
-      <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+      <Dialog
+        open={isModalOpen}
+        onOpenChange={(open) => {
+          if (open) setIsModalOpen(true);
+          else closeModal();
+        }}
+      >
         <DialogContent className="sm:max-w-[600px] max-h-[80vh] overflow-y-auto">
-          <DialogHeader className="flex flex-row items-center justify-between">
+          <DialogHeader className="flex items-center">
             <DialogTitle className="text-xl font-semibold">Crear publicación</DialogTitle>
-            <Button 
-              variant="ghost" 
-              size="sm" 
-              onClick={closeModal}
-              className="h-8 w-8 p-0"
-            >
-              <X className="h-4 w-4" />
-            </Button>
           </DialogHeader>
           
           <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
## Summary
- import and render FacebookStyleComposer in feed page
- remove redundant close icon and simplify quick action labels
- clean unused imports

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b540e2400c8321817b4e3beac8d21d