### PR TITLE
fix: handle marketplace tags arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Handle marketplace product tags provided as arrays or comma-separated strings to prevent runtime errors in product detail and search.
 - Fix undefined composer and redundant close button in feed; simplify quick action labels.
 - Fix duplicate default export in `CategoryFilter` component that caused Next.js build failures.
 - Hide main sidebar on mobile screens so it only appears on desktop.

--- a/app/marketplace/page.tsx
+++ b/app/marketplace/page.tsx
@@ -347,7 +347,10 @@ export default function MarketplacePage() {
   const filteredProducts = mockProducts.filter(product => {
     const matchesSearch = product.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
                          product.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                         product.tags.some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()));
+                        (Array.isArray(product.tags)
+                          ? product.tags
+                          : (product.tags ?? '').split(',')
+                        ).some(tag => tag.toLowerCase().includes(searchQuery.toLowerCase()));
     const matchesCategory = selectedCategory === 'Todas' || product.category === selectedCategory;
     const matchesSubcategory = selectedSubcategory === 'Todas' || product.subcategory === selectedSubcategory;
     

--- a/components/marketplace/ProductCard.tsx
+++ b/components/marketplace/ProductCard.tsx
@@ -26,7 +26,7 @@ interface Product {
     username: string;
   } | null;
   images: string[];
-  tags?: string;
+  tags?: string[] | string;
   createdAt: Date | string;
   isFeatured: boolean;
   favoriteCount?: number;

--- a/components/marketplace/ProductDetail.tsx
+++ b/components/marketplace/ProductDetail.tsx
@@ -45,7 +45,7 @@ interface Product {
     username: string;
   } | null;
   images: string[];
-  tags?: string;
+  tags?: string[] | string;
   createdAt: Date | string;
   isFeatured: boolean;
   favoriteCount?: number;
@@ -234,7 +234,10 @@ export default function ProductDetail({ product, onBack }: ProductDetailProps) {
                         <div>
                           <h4 className="font-semibold text-gray-900 mb-2">Etiquetas</h4>
                           <div className="flex flex-wrap gap-2">
-                            {product.tags.split(',').map((tag, index) => (
+                            {(Array.isArray(product.tags)
+                              ? product.tags
+                              : (product.tags as string).split(',')
+                            ).map((tag, index) => (
                               <Badge key={index} variant="secondary" className="bg-purple-100 text-purple-700">
                                 <Tag className="w-3 h-3 mr-1" />
                                 {tag.trim()}


### PR DESCRIPTION
## Summary
- allow marketplace products to provide tags as arrays or comma-separated strings
- guard product search against non-array tags
- document tag handling in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b546df3e988321b3e1a1f80276e153