### PR TITLE
fix: default cart items to avoid reduce errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Default cart items to an empty array in `ShoppingCart` to prevent `reduce` on `undefined` errors when the cart is uninitialized.
 - Handle marketplace product tags provided as arrays or comma-separated strings to prevent runtime errors in product detail and search.
 - Fix undefined composer and redundant close button in feed; simplify quick action labels.
 - Fix duplicate default export in `CategoryFilter` component that caused Next.js build failures.

--- a/components/marketplace/ShoppingCart.tsx
+++ b/components/marketplace/ShoppingCart.tsx
@@ -25,7 +25,12 @@ interface CartItem {
 }
 
 interface ShoppingCartProps {
-  items: CartItem[];
+  /**
+   * Optional list of cart items. Defaults to an empty array to avoid
+   * `reduce` on `undefined` runtime errors when the cart has not been
+   * initialized.
+   */
+  items?: CartItem[];
   isOpen: boolean;
   onClose: () => void;
   onUpdateQuantity: (itemId: string, quantity: number) => void;
@@ -34,7 +39,7 @@ interface ShoppingCartProps {
 }
 
 export function ShoppingCart({
-  items,
+  items = [],
   isOpen,
   onClose,
   onUpdateQuantity,
@@ -44,8 +49,14 @@ export function ShoppingCart({
   const [isProcessing, setIsProcessing] = useState(false);
 
   const totalItems = items.reduce((sum, item) => sum + item.quantity, 0);
-  const totalCrolars = items.reduce((sum, item) => sum + (item.price * item.quantity), 0);
-  const totalSoles = items.reduce((sum, item) => sum + (item.priceInSoles * item.quantity), 0);
+  const totalCrolars = items.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
+  const totalSoles = items.reduce(
+    (sum, item) => sum + item.priceInSoles * item.quantity,
+    0
+  );
 
   const handleQuantityChange = (itemId: string, newQuantity: number) => {
     const item = items.find(i => i.id === itemId);


### PR DESCRIPTION
## Summary
- default cart items to an empty array in `ShoppingCart` to prevent `reduce` on `undefined`
- document change in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b548b304a483219476e18940b7a7b8