### PR TITLE
fix: stabilize feed store selectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Wrap notifications API calls with a development debug fetch that counts usage.
 - Add global error boundary to log errors and offer reload or home navigation.
 - Guard club president access and details when data is missing to avoid runtime errors.
+- Split feed store selectors to prevent infinite re-render loops.
+- Correct missing Smile icon in Facebook-style composer.
 - Reorganize project by moving useful modules out of legacy `src` directory, consolidating components, hooks, types, store, and utilities under root paths.
 - Allow optional `includeActivity` parameter in `/api/clubs/my-clubs` to prevent validation failures when omitted.
 - Normalize club tag data to handle strings and prevent `slice(...).map` runtime errors in club cards and detail views.

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,6 @@
-import NextAuth from 'next-auth';
-import { authOptions } from '@/lib/auth';
+import NextAuth from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
-const handler = NextAuth(authOptions);
+const handler = NextAuth(authOptions)
 
-export { handler as GET, handler as POST };
+export { handler as GET, handler as POST, authOptions }

--- a/app/api/media/[id]/route.ts
+++ b/app/api/media/[id]/route.ts
@@ -190,3 +190,7 @@ export async function DELETE(
     console.error('Error deleting media:', error)
     return NextResponse.json(
       { error: 'Failed to delete media' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/media/route.ts
+++ b/app/api/media/route.ts
@@ -107,3 +107,4 @@ export async function GET(request: NextRequest) {
       { status: 500 }
     )
   }
+}

--- a/components/feed/FacebookStyleComposer.tsx
+++ b/components/feed/FacebookStyleComposer.tsx
@@ -476,7 +476,7 @@ export function FacebookStyleComposer() {
                     }
                   }}
                 >
-                  <Smile className="h-4 w-4 mr-2" />
+                  <SmileIcon className="h-4 w-4 mr-2" />
                   Emoji 🙂
                 </Button>
                 <Button 

--- a/components/feed/PostList.tsx
+++ b/components/feed/PostList.tsx
@@ -20,7 +20,7 @@ import {
 import { useFeed, useFireReaction } from '@/hooks/useFeed';
 import { FeedPost } from '@/types/feed';
 import { toast } from 'sonner';
-import { CommentModal } from './CommentModal';
+import CommentModal from './CommentModal';
 import { MediaViewer } from './MediaViewer';
 
 // Helper function to format time ago

--- a/store/feedStore.ts
+++ b/store/feedStore.ts
@@ -313,42 +313,75 @@ export const useFeedStore = create<FeedStore>()(persist(
 
 // Selectors for better performance
 export const useComposer = () => useFeedStore((state) => state.composer);
-export const useComposerActions = () => useFeedStore((state) => ({
-  setComposerOpen: state.setComposerOpen,
-  setComposerTab: state.setComposerTab,
-  setComposerText: state.setComposerText,
-  setComposerMedia: state.setComposerMedia,
-  addComposerMedia: state.addComposerMedia,
-  removeComposerMedia: state.removeComposerMedia,
-  setComposerVisibility: state.setComposerVisibility,
-  setComposerHashtags: state.setComposerHashtags,
-  addComposerHashtag: state.addComposerHashtag,
-  removeComposerHashtag: state.removeComposerHashtag,
-  setComposerSubmitting: state.setComposerSubmitting,
-  resetComposer: state.resetComposer,
-}));
+export const useComposerActions = () => {
+  const setComposerOpen = useFeedStore((state) => state.setComposerOpen);
+  const setComposerTab = useFeedStore((state) => state.setComposerTab);
+  const setComposerText = useFeedStore((state) => state.setComposerText);
+  const setComposerMedia = useFeedStore((state) => state.setComposerMedia);
+  const addComposerMedia = useFeedStore((state) => state.addComposerMedia);
+  const removeComposerMedia = useFeedStore((state) => state.removeComposerMedia);
+  const setComposerVisibility = useFeedStore((state) => state.setComposerVisibility);
+  const setComposerHashtags = useFeedStore((state) => state.setComposerHashtags);
+  const addComposerHashtag = useFeedStore((state) => state.addComposerHashtag);
+  const removeComposerHashtag = useFeedStore((state) => state.removeComposerHashtag);
+  const setComposerSubmitting = useFeedStore((state) => state.setComposerSubmitting);
+  const resetComposer = useFeedStore((state) => state.resetComposer);
+
+  return {
+    setComposerOpen,
+    setComposerTab,
+    setComposerText,
+    setComposerMedia,
+    addComposerMedia,
+    removeComposerMedia,
+    setComposerVisibility,
+    setComposerHashtags,
+    addComposerHashtag,
+    removeComposerHashtag,
+    setComposerSubmitting,
+    resetComposer,
+  };
+};
 
 export const useUI = () => useFeedStore((state) => state.ui);
-export const useUIActions = () => useFeedStore((state) => ({
-  setSidebarCollapsed: state.setSidebarCollapsed,
-  setTheme: state.setTheme,
-  setCompactMode: state.setCompactMode,
-  setAutoPlayVideos: state.setAutoPlayVideos,
-  setShowNotifications: state.setShowNotifications,
-}));
+export const useUIActions = () => {
+  const setSidebarCollapsed = useFeedStore((state) => state.setSidebarCollapsed);
+  const setTheme = useFeedStore((state) => state.setTheme);
+  const setCompactMode = useFeedStore((state) => state.setCompactMode);
+  const setAutoPlayVideos = useFeedStore((state) => state.setAutoPlayVideos);
+  const setShowNotifications = useFeedStore((state) => state.setShowNotifications);
+
+  return {
+    setSidebarCollapsed,
+    setTheme,
+    setCompactMode,
+    setAutoPlayVideos,
+    setShowNotifications,
+  };
+};
 
 export const usePreferences = () => useFeedStore((state) => state.preferences);
 export const useKeyboard = () => useFeedStore((state) => state.keyboard);
-export const useCurrentFeed = () => useFeedStore((state) => ({
-  ranking: state.currentRanking,
-  filter: state.currentFilter,
-  selectedPostId: state.selectedPostId,
-}));
+export const useCurrentFeed = () => {
+  const ranking = useFeedStore((state) => state.currentRanking);
+  const filter = useFeedStore((state) => state.currentFilter);
+  const selectedPostId = useFeedStore((state) => state.selectedPostId);
 
-export const useFeedActions = () => useFeedStore((state) => ({
-  setCurrentRanking: state.setCurrentRanking,
-  setCurrentFilter: state.setCurrentFilter,
-  clearCurrentFilter: state.clearCurrentFilter,
-  setSelectedPostId: state.setSelectedPostId,
-  trackEvent: state.trackEvent,
-}));
+  return { ranking, filter, selectedPostId };
+};
+
+export const useFeedActions = () => {
+  const setCurrentRanking = useFeedStore((state) => state.setCurrentRanking);
+  const setCurrentFilter = useFeedStore((state) => state.setCurrentFilter);
+  const clearCurrentFilter = useFeedStore((state) => state.clearCurrentFilter);
+  const setSelectedPostId = useFeedStore((state) => state.setSelectedPostId);
+  const trackEvent = useFeedStore((state) => state.trackEvent);
+
+  return {
+    setCurrentRanking,
+    setCurrentFilter,
+    clearCurrentFilter,
+    setSelectedPostId,
+    trackEvent,
+  };
+};


### PR DESCRIPTION
## Summary
- avoid unstable getSnapshot in feed store selectors
- fix missing Smile icon and comment modal import
- repair media API routes and expose auth options

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5c5627dc08321b8ba7138ea9d0e14