### PR TITLE
Add aria-label to interest removal button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Add aria-label to interest removal button for better accessibility.
+
 - Provide toast and loading components for events pages and coerce `page` and `limit` query parameters to numbers to avoid module resolution and validation errors.
 - Add missing events components and helpers so the events pages build without module resolution errors.
 - Default cart items to an empty array in `ShoppingCart` to prevent `reduce` on `undefined` errors when the cart is uninitialized.

--- a/components/perfil/ProfileEditor.tsx
+++ b/components/perfil/ProfileEditor.tsx
@@ -356,6 +356,7 @@ export default function ProfileEditor({ profile, onSave, onCancel }: ProfileEdit
                   <button
                     onClick={() => handleRemoveInterest(interest)}
                     className="ml-1 hover:text-red-500"
+                    aria-label="Eliminar interés"
                   >
                     <X className="h-3 w-3" />
                   </button>


### PR DESCRIPTION
## Summary
- describe interest removal button with `aria-label` for accessibility
- document change in changelog

## Testing
- `npm test`
- `npm run lint` *(fails: 'likeCount' is never reassigned. Use 'const' instead)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e791841883218d64664345164950