### PR TITLE
fix: guard MediaViewer against missing media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix duplicate default export in `CategoryFilter` component that caused Next.js build failures.
 - Hide main sidebar on mobile screens so it only appears on desktop.
 - Simplify feed layout by removing the left column, widening the timeline, adding a closable weekly challenge banner, and moving the user level card to the global sidebar.
+- Guard media viewer against missing media to prevent undefined `type` errors when opening feed posts.
 
 - Add user stats and trending topics API endpoints to resolve profile and feed 404 errors.
 - Provide default and placeholder avatars to eliminate broken image requests.

--- a/components/feed/MediaViewer.tsx
+++ b/components/feed/MediaViewer.tsx
@@ -90,7 +90,7 @@ export function MediaViewer({ isOpen, onClose, post, initialMediaIndex = 0 }: Me
   const [likeCount, setLikeCount] = useState(post.stats.likes);
   const [isSubmittingComment, setIsSubmittingComment] = useState(false);
 
-  const currentMedia = post.media[currentIndex];
+  const currentMedia = post.media?.[currentIndex];
   const hasMultipleMedia = post.media.length > 1;
 
   // Load comments when viewer opens
@@ -165,6 +165,7 @@ export function MediaViewer({ isOpen, onClose, post, initialMediaIndex = 0 }: Me
   };
 
   const handleDownload = async () => {
+    if (!currentMedia) return;
     try {
       const response = await fetch(currentMedia.url);
       const blob = await response.blob();
@@ -244,7 +245,7 @@ export function MediaViewer({ isOpen, onClose, post, initialMediaIndex = 0 }: Me
           handleNext();
           break;
         case ' ':
-          if (currentMedia.type === 'video') {
+          if (currentMedia?.type === 'video') {
             e.preventDefault();
             setIsPlaying(prev => !prev);
           }
@@ -254,9 +255,9 @@ export function MediaViewer({ isOpen, onClose, post, initialMediaIndex = 0 }: Me
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose, handlePrevious, handleNext, currentMedia.type]);
+  }, [isOpen, onClose, handlePrevious, handleNext, currentMedia?.type]);
 
-  if (!isOpen) return null;
+  if (!isOpen || !currentMedia) return null;
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>


### PR DESCRIPTION
## Summary
- avoid undefined errors by safely handling missing media in feed MediaViewer
- document fix in changelog

## Testing
- `npm test`
- `npm run lint` *(fails: 'prefer-const' errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e8c4724883219739bc16f68096e0