### PR TITLE
Remove redundant Feed navigation item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add aria-label to interest removal button for better accessibility.
 
+- Remove redundant Feed navigation item from sidebar and mobile menus.
+
 - Provide toast and loading components for events pages and coerce `page` and `limit` query parameters to numbers to avoid module resolution and validation errors.
 - Add missing events components and helpers so the events pages build without module resolution errors.
 - Default cart items to an empty array in `ShoppingCart` to prevent `reduce` on `undefined` errors when the cart is uninitialized.

--- a/components/layout/MobileNavbar.tsx
+++ b/components/layout/MobileNavbar.tsx
@@ -9,7 +9,7 @@ import {
   Home, FileText, MessageSquare, Users, Calendar, BookOpen, ShoppingCart,
   Gamepad2, Target, Trophy, Bot, TrendingUp, Bookmark, Coins,
   Upload, HelpCircle, UserPlus, Award, Star, Grid3X3, GraduationCap,
-  ShoppingBag, Zap, Rss, Moon, Sun
+  ShoppingBag, Zap, Moon, Sun
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -28,7 +28,6 @@ interface MenuItem {
 const MENU_ITEMS: MenuItem[] = [
   // Principal
   { key: 'inicio', label: 'Inicio', href: '/', icon: Home },
-  { key: 'feed', label: 'Feed', href: '/feed', icon: Rss },
   { key: 'perfil', label: 'Perfil', href: '/perfil', icon: User },
   { key: 'workspace', label: 'Workspace', href: '/workspace', icon: Grid3X3 },
   { key: 'apunte', label: 'Apunte', href: '/apunte', icon: FileText },

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -31,8 +31,7 @@ import {
   Grid3X3,
   GraduationCap,
   ShoppingBag,
-  Zap,
-  Rss
+  Zap
 } from 'lucide-react'
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -49,7 +48,6 @@ interface SidebarItem {
 
 const mainNavItems: SidebarItem[] = [
   { name: 'Inicio', href: '/', icon: Home },
-  { name: 'Feed', href: '/feed', icon: Rss },
   { name: 'Perfil', href: '/perfil', icon: User },
   { name: 'Workspace', href: '/workspace', icon: Grid3X3, color: 'text-crunevo-600' },
   { name: 'Apuntes', href: '/notes', icon: FileText },


### PR DESCRIPTION
## Summary
- remove Feed link from desktop sidebar
- remove Feed link from mobile drawer
- document nav update in changelog

## Testing
- `npm test`
- `npm run lint` *(fails: 'likeCount' is never reassigned. Use 'const' instead. prefer-const, and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ebbd14808321aef165a9000d7873