### PR TITLE
fix: ajustar creación y renderizado de bloques

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Add Dockerfile and documentation for running PostgreSQL locally with Docker.
+- Fix workspace board rendering and block creation by aligning block types and dimensions between API and frontend.
 
 - Align feed client with API pagination and add single post endpoint for local development.
 - Improve feed post actions: link user names to profiles, move follow button beside author info, restore flame reaction, and add share handling.

--- a/api/workspace/blocks/blocks.service.ts
+++ b/api/workspace/blocks/blocks.service.ts
@@ -175,7 +175,7 @@ export class BlocksService {
 
   private async initializeBlockContent(blockId: string, type: string) {
     switch (type) {
-      case 'docs':
+      case 'DOCS':
         await prisma.docsPage.create({
           data: {
             blockId,
@@ -184,7 +184,7 @@ export class BlocksService {
           },
         });
         break;
-      case 'kanban':
+      case 'KANBAN':
         // Create default columns
         await prisma.kanbanColumn.createMany({
           data: [
@@ -194,7 +194,7 @@ export class BlocksService {
           ],
         });
         break;
-      case 'frases':
+      case 'FRASES':
         // Create a default frases item
         await prisma.frasesItem.create({
           data: {

--- a/api/workspace/blocks/dto/block.dto.ts
+++ b/api/workspace/blocks/dto/block.dto.ts
@@ -11,7 +11,7 @@ import {
 } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-const BLOCK_TYPES = ['docs', 'kanban', 'frases'] as const;
+const BLOCK_TYPES = ['DOCS', 'KANBAN', 'FRASES'] as const;
 
 export class CreateBlockDto {
   @ApiProperty({
@@ -24,7 +24,7 @@ export class CreateBlockDto {
   @ApiProperty({
     description: 'Type of the block',
     enum: BLOCK_TYPES,
-    example: 'docs',
+    example: 'DOCS',
   })
   @IsString()
   @IsIn(BLOCK_TYPES)
@@ -164,6 +164,14 @@ export class UpdateBlockDto {
   @IsOptional()
   @IsBoolean()
   locked?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Whether the block is completed',
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  completed?: boolean;
 }
 
 export class UpdateBlockPositionDto {

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -97,21 +97,26 @@ export default function WorkspacePage() {
   };
 
   // Handle block creation
-  const handleCreateBlock = async (blockData: any) => {
+  const handleCreateBlock = async (
+    type: 'DOCS' | 'KANBAN' | 'FRASES',
+    title: string,
+  ) => {
     if (!currentBoard) return;
-    
+
     try {
-      // Generate random position
+      // Generate random position for the new block
       const position = {
         x: Math.random() * 400 + 100,
-        y: Math.random() * 300 + 100
+        y: Math.random() * 300 + 100,
       };
-      
+
       await createBlock(currentBoard.id, {
-        ...blockData,
-        position,
+        type,
+        title,
+        x: position.x,
+        y: position.y,
       });
-      
+
       setShowCreateModal(false);
     } catch (error) {
       // Error handled by hook

--- a/components/workspace/WorkspaceBlock.tsx
+++ b/components/workspace/WorkspaceBlock.tsx
@@ -15,8 +15,8 @@ interface WorkspaceBlockData {
   title: string;
   x: number;
   y: number;
-  width: number;
-  height: number;
+  w: number;
+  h: number;
   zIndex: number;
   completed: boolean;
   createdAt: string;
@@ -55,7 +55,7 @@ export function WorkspaceBlock({
   const [isDragging, setIsDragging] = useState(false);
   const [isResizing, setIsResizing] = useState(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
-  const [resizeStart, setResizeStart] = useState({ x: 0, y: 0, width: 0, height: 0 });
+  const [resizeStart, setResizeStart] = useState({ x: 0, y: 0, w: 0, h: 0 });
   const blockRef = useRef<HTMLDivElement>(null);
 
   const Icon = BLOCK_ICONS[block.type];
@@ -83,8 +83,8 @@ export function WorkspaceBlock({
     setResizeStart({
       x: e.clientX,
       y: e.clientY,
-      width: block.width,
-      height: block.height,
+      w: block.w,
+      h: block.h,
     });
   };
 
@@ -97,20 +97,20 @@ export function WorkspaceBlock({
         
         onUpdate({
           ...block,
-          x: Math.max(0, Math.min(5000 - block.width, newX)),
-          y: Math.max(0, Math.min(5000 - block.height, newY)),
+          x: Math.max(0, Math.min(5000 - block.w, newX)),
+          y: Math.max(0, Math.min(5000 - block.h, newY)),
         });
       } else if (isResizing) {
         const deltaX = e.clientX - resizeStart.x;
         const deltaY = e.clientY - resizeStart.y;
         
-        const newWidth = Math.max(300, Math.min(800, resizeStart.width + deltaX / zoom));
-        const newHeight = Math.max(200, Math.min(600, resizeStart.height + deltaY / zoom));
+        const newWidth = Math.max(300, Math.min(800, resizeStart.w + deltaX / zoom));
+        const newHeight = Math.max(200, Math.min(600, resizeStart.h + deltaY / zoom));
         
         onUpdate({
           ...block,
-          width: newWidth,
-          height: newHeight,
+          w: newWidth,
+          h: newHeight,
         });
       }
     };
@@ -140,13 +140,13 @@ export function WorkspaceBlock({
   const updateBlockOnServer = async () => {
     try {
       await fetch(`/api/workspace/blocks/${block.id}`, {
-        method: 'PATCH',
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           x: block.x,
           y: block.y,
-          w: block.width,
-          h: block.height,
+          w: block.w,
+          h: block.h,
         }),
       });
     } catch (error) {
@@ -173,7 +173,7 @@ export function WorkspaceBlock({
   const toggleCompletion = async () => {
     try {
       const response = await fetch(`/api/workspace/blocks/${block.id}`, {
-        method: 'PATCH',
+        method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ completed: !block.completed }),
       });
@@ -195,8 +195,8 @@ export function WorkspaceBlock({
       style={{
         left: canvasOffset.x + block.x * zoom,
         top: canvasOffset.y + block.y * zoom,
-        width: block.width * zoom,
-        height: block.height * zoom,
+        width: block.w * zoom,
+        height: block.h * zoom,
         zIndex: block.zIndex,
         transform: `scale(${zoom})`,
         transformOrigin: 'top left',

--- a/hooks/useWorkspace.ts
+++ b/hooks/useWorkspace.ts
@@ -27,8 +27,8 @@ export interface WorkspaceBlockData {
   title: string;
   x: number;
   y: number;
-  width: number;
-  height: number;
+  w: number;
+  h: number;
   zIndex: number;
   completed: boolean;
   isPublic: boolean;
@@ -234,8 +234,8 @@ export function useWorkspace(): UseWorkspaceReturn {
           boardId,
           x: data.x ?? Math.random() * 500,
           y: data.y ?? Math.random() * 500,
-          width: 300,
-          height: 200,
+          w: 300,
+          h: 200,
         }),
       });
       


### PR DESCRIPTION
## Summary
- corrige creación de bloques desde la pizarra y normaliza dimensiones
- unifica tipos de bloque entre frontend y API

## Testing
- `npm test` *(fails: useNotifications calls loadNotifications once and does not recreate EventSource)*
- `npm run lint` *(fails: React Hook "useEffect" is called conditionally, prefer-const, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b7910574b08321950de026e400ab7c