### PR TITLE
fix(workspace): pasar offset y zoom a los bloques

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add Dockerfile and documentation for running PostgreSQL locally with Docker.
 - Fix workspace board rendering and block creation by aligning block types and dimensions between API and frontend.
+- Pass canvas offset and zoom to workspace blocks so pizarra interactions update and display correctly.
 
 - Align feed client with API pagination and add single post endpoint for local development.
 - Improve feed post actions: link user names to profiles, move follow button beside author info, restore flame reaction, and add share handling.

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -310,8 +310,21 @@ export default function WorkspacePage() {
                     key={block.id}
                     block={block}
                     isEditMode={isEditMode}
+                    canvasOffset={canvasOffset}
+                    zoom={zoom}
                     onUpdate={(updatedBlock) => {
-                      // Block updates are handled by WorkspaceBlock component
+                      setCurrentBoard(prev => prev ? {
+                        ...prev,
+                        blocks: prev.blocks.map(b =>
+                          b.id === updatedBlock.id ? updatedBlock : b
+                        )
+                      } : null);
+                    }}
+                    onDelete={(blockId) => {
+                      setCurrentBoard(prev => prev ? {
+                        ...prev,
+                        blocks: prev.blocks.filter(b => b.id !== blockId)
+                      } : null);
                     }}
                   />
                 ))}


### PR DESCRIPTION
## Resumen
- Propagar `canvasOffset` y `zoom` a `WorkspaceBlock` para que los bloques reflejen sus posiciones y eliminaciones.
- Actualizar `CHANGELOG` con la corrección de la pizarra.

## Testing
- `npm test` *(falló: useNotifications: calls loadNotifications once and does not recreate EventSource)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b79375610883219a8976047e74fa3d