### PR TITLE
fix: handle workspace stats endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Add workspace stats API and align stats hook to avoid HTML error when loading pizarra statistics.
 - Add Dockerfile and documentation for running PostgreSQL locally with Docker.
 - Fix workspace board rendering and block creation by aligning block types and dimensions between API and frontend.
 - Pass canvas offset and zoom to workspace blocks so pizarra interactions update and display correctly.

--- a/app/api/workspace/stats/route.ts
+++ b/app/api/workspace/stats/route.ts
@@ -1,0 +1,32 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+import { prisma } from '@/lib/prisma';
+import { getSession } from '@/lib/session';
+import { proxyWorkspace } from '@/lib/workspace-proxy';
+
+export async function GET(req: Request) {
+  const proxy = await proxyWorkspace(req, '/stats');
+  if (proxy) return proxy;
+  try {
+    const session = await getSession();
+    if (!session?.user?.id) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    const userId = session.user.id;
+    const [boardsCount, blocksCount, docsCount, kanbanCount, frasesCount] = await Promise.all([
+      prisma.workspaceBoard.count({ where: { userId } }),
+      prisma.workspaceBlock.count({ where: { board: { userId } } }),
+      prisma.docsPage.count({ where: { block: { board: { userId } } } }),
+      prisma.kanbanColumn.count({ where: { block: { board: { userId } } } }),
+      prisma.frasesItem.count({ where: { block: { board: { userId } } } }),
+    ]);
+    return Response.json({
+      stats: { boardsCount, blocksCount, docsCount, kanbanCount, frasesCount },
+    });
+  } catch (e) {
+    console.error('[GET /api/workspace/stats]', e);
+    return Response.json({ error: 'Internal error' }, { status: 500 });
+  }
+}

--- a/hooks/useWorkspace.ts
+++ b/hooks/useWorkspace.ts
@@ -56,13 +56,13 @@ export interface WorkspaceCollaborator {
 }
 
 export interface WorkspaceStats {
-  boards: number;
-  blocks: number;
-  docs: number;
-  kanban: number;
-  frases: number;
-  collaborators: number;
-  sharedBoards: number;
+  boardsCount: number;
+  blocksCount: number;
+  docsCount: number;
+  kanbanCount: number;
+  frasesCount: number;
+  collaboratorsCount?: number;
+  sharedBoardsCount?: number;
 }
 
 export interface UseWorkspaceReturn {


### PR DESCRIPTION
## Summary
- expose workspace stats API route
- align stats hook fields with API
- log change in changelog

## Testing
- `npm test` *(fails: useNotifications calls were not triggered)*
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm run check-workspace` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b799587a3c8321a47bf566ed0836ad