### PR TITLE
fix: allow case insensitive profile lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Normalize usernames to lowercase on write, allow case-insensitive lookups, and redirect to the canonical username.
+- Add `/api/users/profile` to fetch the authenticated user profile with stats.
+- Enforce case-insensitive username uniqueness at the database level with a `lower(username)` unique index and backfill.
 - Make username lookups case-insensitive and normalize registration to lowercase to prevent profile access failures.
 - Fix feed interactions: animate and persist fire reactions, expose full post menu actions, and handle comment errors gracefully.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Make username lookups case-insensitive and normalize registration to lowercase to prevent profile access failures.
 - Fix feed interactions: animate and persist fire reactions, expose full post menu actions, and handle comment errors gracefully.
 
 - Allow feed posts without text by relaxing server validation while ensuring content or media is provided.

--- a/api/users/[username].ts
+++ b/api/users/[username].ts
@@ -19,8 +19,13 @@ export default async function handler(
         const session = await getServerSession(req, res, authOptions);
         const currentUserId = session?.user?.id;
 
-        const user = await prisma.user.findUnique({
-          where: { username },
+        const user = await prisma.user.findFirst({
+          where: {
+            username: {
+              equals: username as string,
+              mode: 'insensitive'
+            }
+          },
           include: {
             userVerification: true,
             userAnalytics: true,

--- a/api/users/[username].ts
+++ b/api/users/[username].ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { getServerSession } from 'next-auth/next';
 import { authOptions } from '../auth/[...nextauth]';
 import { prisma } from '@/lib/prisma';
+import { USERNAME_REGEX } from '@/lib/validation';
 
 export default async function handler(
   req: NextApiRequest,
@@ -9,8 +10,8 @@ export default async function handler(
 ) {
   const { username } = req.query;
 
-  if (!username || typeof username !== 'string') {
-    return res.status(400).json({ error: 'Username requerido' });
+  if (!username || typeof username !== 'string' || !USERNAME_REGEX.test(username)) {
+    return res.status(400).json({ error: 'Username inválido' });
   }
 
   switch (req.method) {

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -24,6 +24,7 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
     const { email, password, username, name } = registerSchema.parse(body);
+    const normalizedUsername = username.toLowerCase();
 
     // Verificar si el email ya existe
     const existingUserByEmail = await prisma.user.findUnique({
@@ -37,9 +38,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Verificar si el username ya existe
-    const existingUserByUsername = await prisma.user.findUnique({
-      where: { username }
+    // Verificar si el username ya existe (sin distinguir mayúsculas)
+    const existingUserByUsername = await prisma.user.findFirst({
+      where: {
+        username: {
+          equals: normalizedUsername,
+          mode: 'insensitive'
+        }
+      }
     });
 
     if (existingUserByUsername) {
@@ -57,7 +63,7 @@ export async function POST(request: NextRequest) {
       data: {
         email,
         password: hashedPassword,
-        username,
+        username: normalizedUsername,
         name,
         image: '/default-avatar.png',
         emailVerified: null, // Se puede implementar verificación por email después

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -3,11 +3,19 @@ import { hash } from 'bcryptjs';
 import { prisma } from '@/lib/prisma';
 import { z } from 'zod';
 import { rateLimitRegister } from '@/lib/rate-limit';
+import { USERNAME_REGEX } from '@/lib/validation';
 
 const registerSchema = z.object({
   email: z.string().email('Email inválido'),
   password: z.string().min(6, 'La contraseña debe tener al menos 6 caracteres'),
-  username: z.string().min(3, 'El username debe tener al menos 3 caracteres').max(20, 'El username no puede tener más de 20 caracteres'),
+  username: z
+    .string()
+    .min(3, 'El username debe tener al menos 3 caracteres')
+    .max(20, 'El username no puede tener más de 20 caracteres')
+    .regex(
+      USERNAME_REGEX,
+      'El username solo puede contener letras, números, puntos, guiones y guiones bajos'
+    ),
   name: z.string().min(1, 'El nombre es requerido').max(50, 'El nombre no puede tener más de 50 caracteres'),
 });
 

--- a/app/api/users/profile/route.ts
+++ b/app/api/users/profile/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth/next'
+import { authOptions } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions)
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: {
+        id: true,
+        name: true,
+        username: true,
+        email: true,
+        image: true,
+        bio: true,
+        verified: true,
+        createdAt: true,
+        _count: { select: { posts: true, followers: true, following: true } }
+      }
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({
+      ...user,
+      postsCount: user._count.posts,
+      followersCount: user._count.followers,
+      followingCount: user._count.following,
+      isOwnProfile: true
+    })
+  } catch (error) {
+    console.error('Error fetching profile:', error)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,8 @@ module.exports = {
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1'
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: { jsx: 'react-jsx' } }]
   }
 };

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -234,8 +234,13 @@ export async function getUserByEmail(email: string): Promise<{
 // Helper function to get user by username
 export async function getUserByUsername(username: string): Promise<User | null> {
   try {
-    return await prisma.user.findUnique({
-      where: { username }
+    return await prisma.user.findFirst({
+      where: {
+        username: {
+          equals: username,
+          mode: 'insensitive'
+        }
+      }
     });
   } catch (error) {
     console.error('Error getting user by username:', error);
@@ -255,12 +260,14 @@ export async function createUser(userData: {
   try {
     const hashedPassword = await hashPassword(userData.password);
     
+    const normalizedUsername = userData.username.toLowerCase();
+
     return await prisma.user.create({
       data: {
         email: userData.email,
         password: hashedPassword,
         name: userData.name,
-        username: userData.username,
+        username: normalizedUsername,
         image: '/default-avatar.png',
         birthDate: userData.dateOfBirth,
         gender: userData.gender,

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,1 @@
+export const USERNAME_REGEX = /^[a-z0-9._-]{3,20}$/i;

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "jest": "^30.1.1",
         "jest-environment-jsdom": "^30.1.1",
         "nodemon": "^3.1.10",
+        "pg-mem": "^3.0.5",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.4.1",
@@ -7119,6 +7120,25 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -7971,6 +7991,24 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -8063,6 +8101,13 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -9465,6 +9510,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9726,6 +9778,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -9881,6 +9946,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
+      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -10116,6 +10188,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11339,6 +11418,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11357,6 +11456,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -11824,6 +11933,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/motion-dom": {
       "version": "12.23.12",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
@@ -11943,6 +12069,36 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12300,6 +12456,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -12623,6 +12789,106 @@
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
+    },
+    "node_modules/pg-mem": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
+      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.1"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg-mem/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pg-mem/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
+      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -13044,6 +13310,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13434,6 +13721,16 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -13671,6 +13968,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "jest": "^30.1.1",
     "jest-environment-jsdom": "^30.1.1",
     "nodemon": "^3.1.10",
+    "pg-mem": "^3.0.5",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.4.1",

--- a/prisma/migrations/20250205000000_usernames_case_insensitive/migration.sql
+++ b/prisma/migrations/20250205000000_usernames_case_insensitive/migration.sql
@@ -1,0 +1,22 @@
+-- Enforce case-insensitive uniqueness for usernames
+BEGIN;
+
+-- 1) Resolve case-insensitive collisions by keeping the oldest username and renaming others with suffix -{n}
+WITH duplicates AS (
+  SELECT id, username, LOWER(username) AS lower_name,
+         ROW_NUMBER() OVER (PARTITION BY LOWER(username) ORDER BY "createdAt") AS rn
+  FROM "User"
+)
+UPDATE "User" u
+SET username = d.lower_name || '-' || d.rn
+FROM duplicates d
+WHERE u.id = d.id AND d.rn > 1;
+
+-- 2) Force all usernames to lowercase
+UPDATE "User" SET username = LOWER(username);
+
+-- 3) Create unique index on lower(username)
+DROP INDEX IF EXISTS users_username_lower_idx;
+CREATE UNIQUE INDEX users_username_lower_idx ON "User"(LOWER(username));
+
+COMMIT;

--- a/tests/user-system.test.ts
+++ b/tests/user-system.test.ts
@@ -1,0 +1,142 @@
+jest.mock('next/server', () => ({
+  NextResponse: class {
+    constructor(public body: any, public init?: any) {}
+    static json(body: any, init?: any) {
+      return new this(body, init)
+    }
+    json() {
+      return Promise.resolve(this.body)
+    }
+    get status() {
+      return this.init?.status || 200
+    }
+  },
+  NextRequest: class {}
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn()
+    }
+  }
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  rateLimitRegister: jest.fn().mockResolvedValue({ success: true })
+}))
+
+jest.mock('next-auth/next', () => ({ getServerSession: jest.fn() }))
+jest.mock('next-auth', () => ({ getServerSession: jest.fn() }))
+
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    const err = new Error(`REDIRECT:${url}`)
+    ;(err as any).digest = 'NEXT_REDIRECT'
+    throw err
+  },
+  notFound: () => {
+    const err = new Error('NOT_FOUND')
+    ;(err as any).digest = 'NEXT_NOT_FOUND'
+    throw err
+  }
+}))
+
+jest.mock('@/components/user/EnhancedProfile', () => ({
+  EnhancedProfile: () => null
+}))
+
+jest.mock('@/lib/auth', () => ({
+  ...jest.requireActual('@/lib/auth'),
+  authOptions: {} as any
+}))
+
+import { POST as register } from '@/app/api/auth/register/route'
+import { GET as getOwnProfile } from '@/app/api/users/profile/route'
+import { GET as getUser } from '@/app/api/users/[id]/route'
+import ProfilePage from '@/app/u/[username]/page'
+import { getUserByUsername } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { newDb } from 'pg-mem'
+const prismaMock = (prisma as any).user
+const getServerSessionNext = require('next-auth/next').getServerSession as jest.Mock
+const getServerSession = require('next-auth').getServerSession as jest.Mock
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+test('register normalizes username to lowercase', async () => {
+  prismaMock.findUnique.mockResolvedValue(null)
+  prismaMock.findFirst.mockResolvedValue(null)
+  prismaMock.create.mockResolvedValue({ id: '1', email: 'a@example.com', username: 'rogger', name: 'Rogger', createdAt: new Date() })
+
+  const req = { json: async () => ({ email: 'a@example.com', password: 'secret', username: 'Rogger', name: 'Rogger' }) } as any
+  await register(req)
+  expect(prismaMock.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ username: 'rogger' }) }))
+})
+
+test('getUserByUsername matches case-insensitively', async () => {
+  prismaMock.findFirst.mockResolvedValue({ id: '1', username: 'rogger' })
+  const user = await getUserByUsername('ROGGER')
+  expect(user?.username).toBe('rogger')
+})
+
+test('GET /u/ROGGER redirects to canonical lowercase', async () => {
+  prismaMock.findFirst.mockResolvedValue({ id: '1', username: 'rogger' })
+  await expect(ProfilePage({ params: { username: 'ROGGER' } })).rejects.toThrow('REDIRECT:/u/rogger')
+})
+
+test('GET /api/users/[id] returns profile for uppercase username', async () => {
+  getServerSessionNext.mockResolvedValue(null)
+  prismaMock.findFirst.mockResolvedValue({
+    id: '1',
+    name: 'Rogger',
+    username: 'rogger',
+    email: 'a',
+    image: null,
+    bio: null,
+    verified: false,
+    createdAt: new Date(),
+    _count: { posts: 0, followers: 0, following: 0 },
+    followers: []
+  })
+  const res = await getUser({} as any, { params: { id: 'ROGGER' } })
+  const json = await res.json()
+  expect(json.username).toBe('rogger')
+})
+
+test('GET /api/users/profile requires session', async () => {
+  getServerSessionNext.mockResolvedValueOnce(null)
+  const res = await getOwnProfile()
+  expect(res.status).toBe(401)
+})
+
+test('GET /api/users/profile returns profile with counts', async () => {
+  getServerSessionNext.mockResolvedValueOnce({ user: { id: '1' } })
+  prismaMock.findUnique.mockResolvedValueOnce({
+    id: '1',
+    name: 'Rogger',
+    username: 'rogger',
+    email: 'a',
+    image: null,
+    bio: null,
+    verified: false,
+    createdAt: new Date(),
+    _count: { posts: 5, followers: 2, following: 3 }
+  })
+  const res = await getOwnProfile()
+  const json = await res.json()
+  expect(json.isOwnProfile).toBe(true)
+  expect(json.postsCount).toBe(5)
+})
+
+test('DB enforces case-insensitive username uniqueness', () => {
+  const db = newDb()
+  db.public.none('CREATE TABLE "User"(id serial PRIMARY KEY, username text, "createdAt" timestamptz default now())')
+  db.public.none('CREATE UNIQUE INDEX users_username_lower_idx ON "User"(LOWER(username))')
+  db.public.none("INSERT INTO \"User\"(username) VALUES ('Juan')")
+  expect(() => db.public.none("INSERT INTO \"User\"(username) VALUES ('juan')")).toThrow()
+})


### PR DESCRIPTION
## Summary
- make profile pages and user API query usernames case-insensitively
- normalize usernames to lowercase during registration and helper functions
- document case-insensitive username handling in changelog

## Testing
- `npm test`
- `npm run lint` *(fails: React hook dependency warnings and prefer-const errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b888a657ac832187356ad0a6b7eab0