### PR TITLE
Fix workspace block creation and board panning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Allow creating workspace blocks in development and enable canvas panning by fixing block creation handler, updating block rendering with zoom, and ignoring pointer events on the grid.
 - Normalize usernames to lowercase on write, allow case-insensitive lookups, and redirect to the canonical username.
 - Add `/api/users/profile` to fetch the authenticated user profile with stats.
 - Enforce case-insensitive username uniqueness at the database level with a `lower(username)` unique index and backfill.

--- a/app/workspace/page.tsx
+++ b/app/workspace/page.tsx
@@ -97,21 +97,26 @@ export default function WorkspacePage() {
   };
 
   // Handle block creation
-  const handleCreateBlock = async (blockData: any) => {
+  const handleCreateBlock = async (
+    type: 'DOCS' | 'KANBAN' | 'FRASES',
+    title: string
+  ) => {
     if (!currentBoard) return;
-    
+
     try {
       // Generate random position
       const position = {
         x: Math.random() * 400 + 100,
         y: Math.random() * 300 + 100
       };
-      
+
       await createBlock(currentBoard.id, {
-        ...blockData,
-        position,
+        type,
+        title,
+        x: position.x,
+        y: position.y,
       });
-      
+
       setShowCreateModal(false);
     } catch (error) {
       // Error handled by hook
@@ -285,7 +290,7 @@ export default function WorkspacePage() {
               >
                 {/* Grid Background */}
                 <div
-                  className="absolute inset-0"
+                  className="absolute inset-0 pointer-events-none"
                   style={{
                     width: CANVAS_SIZE,
                     height: CANVAS_SIZE,
@@ -305,8 +310,20 @@ export default function WorkspacePage() {
                     key={block.id}
                     block={block}
                     isEditMode={isEditMode}
+                    zoom={zoom}
                     onUpdate={(updatedBlock) => {
-                      // Block updates are handled by WorkspaceBlock component
+                      setCurrentBoard(prev => prev ? {
+                        ...prev,
+                        blocks: prev.blocks.map(b =>
+                          b.id === updatedBlock.id ? updatedBlock : b
+                        )
+                      } : prev);
+                    }}
+                    onDelete={(blockId) => {
+                      setCurrentBoard(prev => prev ? {
+                        ...prev,
+                        blocks: prev.blocks.filter(b => b.id !== blockId)
+                      } : prev);
                     }}
                   />
                 ))}

--- a/components/workspace/WorkspaceBlock.tsx
+++ b/components/workspace/WorkspaceBlock.tsx
@@ -26,7 +26,6 @@ interface WorkspaceBlockData {
 interface WorkspaceBlockProps {
   block: WorkspaceBlockData;
   isEditMode: boolean;
-  canvasOffset: { x: number; y: number };
   zoom: number;
   onUpdate: (block: WorkspaceBlockData) => void;
   onDelete: (blockId: string) => void;
@@ -47,7 +46,6 @@ const BLOCK_COLORS = {
 export function WorkspaceBlock({
   block,
   isEditMode,
-  canvasOffset,
   zoom,
   onUpdate,
   onDelete,
@@ -193,13 +191,11 @@ export function WorkspaceBlock({
         isDragging ? 'cursor-grabbing' : isEditMode ? 'cursor-grab' : 'cursor-pointer'
       }`}
       style={{
-        left: canvasOffset.x + block.x * zoom,
-        top: canvasOffset.y + block.y * zoom,
-        width: block.w * zoom,
-        height: block.h * zoom,
+        left: block.x,
+        top: block.y,
+        width: block.w,
+        height: block.h,
         zIndex: block.zIndex,
-        transform: `scale(${zoom})`,
-        transformOrigin: 'top left',
       }}
     >
       <Card className={`h-full flex flex-col ${BLOCK_COLORS[block.type]} ${block.completed ? 'opacity-75' : ''}`}>


### PR DESCRIPTION
## Summary
- Fix block creation handler to accept type and title
- Remove canvas offset from workspace blocks and pass zoom
- Ignore grid pointer events so canvas panning works

## Testing
- `npm test` *(fails: Expected 5 Received undefined)*
- `npm run lint` *(warnings and rule violations)*

------
https://chatgpt.com/codex/tasks/task_e_68b8948d9b508321a3be7572393c551b