### PR TITLE
fix: normalize email for login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Normalize usernames to lowercase on write, allow case-insensitive lookups, and redirect to the canonical username.
+- Normalize emails to lowercase during registration and login to ensure account recognition after signing out.
 - Add `/api/users/profile` to fetch the authenticated user profile with stats.
 - Enforce case-insensitive username uniqueness at the database level with a `lower(username)` unique index and backfill.
 - Make username lookups case-insensitive and normalize registration to lowercase to prevent profile access failures.

--- a/README-auth.md
+++ b/README-auth.md
@@ -1,6 +1,6 @@
 # Autenticación y rutas
 
-Este proyecto utiliza **NextAuth** y middleware para proteger rutas. Las rutas públicas pueden visitarse sin iniciar sesión; las protegidas redirigen a `/auth/login` (también accesible como `/auth/signin`).
+Este proyecto utiliza **NextAuth** y middleware para proteger rutas. Las rutas públicas pueden visitarse sin iniciar sesión; las protegidas redirigen a `/auth/login` (también accesible como `/auth/signin`). Los correos electrónicos se normalizan a minúsculas en el registro y al iniciar sesión para evitar problemas de identificación.
 
 ## Rutas públicas
 

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -32,11 +32,12 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
     const { email, password, username, name } = registerSchema.parse(body);
+    const normalizedEmail = email.toLowerCase();
     const normalizedUsername = username.toLowerCase();
 
     // Verificar si el email ya existe
     const existingUserByEmail = await prisma.user.findUnique({
-      where: { email }
+      where: { email: normalizedEmail }
     });
 
     if (existingUserByEmail) {
@@ -69,7 +70,7 @@ export async function POST(request: NextRequest) {
     // Crear el usuario
     const user = await prisma.user.create({
       data: {
-        email,
+        email: normalizedEmail,
         password: hashedPassword,
         username: normalizedUsername,
         name,

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -209,8 +209,9 @@ export async function getUserByEmail(email: string): Promise<{
   career: string | null;
 } | null> {
   try {
+    const normalizedEmail = email.toLowerCase();
     return await prisma.user.findUnique({
-      where: { email },
+      where: { email: normalizedEmail },
       select: {
         id: true,
         email: true,
@@ -259,12 +260,12 @@ export async function createUser(userData: {
 }): Promise<User | null> {
   try {
     const hashedPassword = await hashPassword(userData.password);
-    
+    const normalizedEmail = userData.email.toLowerCase();
     const normalizedUsername = userData.username.toLowerCase();
 
     return await prisma.user.create({
       data: {
-        email: userData.email,
+        email: normalizedEmail,
         password: hashedPassword,
         name: userData.name,
         username: normalizedUsername,


### PR DESCRIPTION
## Summary
- normalize email during registration and login
- ensure getUserByEmail and createUser handle lowercase emails
- document email normalization for authentication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b894cd3e0c8321b7078b43f6018f3b