### PR TITLE
Remove pg-mem test dependency and fix lint issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Replace pg-mem dependency in tests with an in-memory Set to simulate case-insensitive username uniqueness.
+- Use const declarations for like and follow counts in API routes and ensure `useEffect` runs consistently on the search page.
 - Show empty state with upload call-to-action on notes page and fix upload modal handling.
 - Allow creating workspace blocks in development and enable canvas panning by fixing block creation handler, updating block rendering with zoom, and ignoring pointer events on the grid.
 - Normalize usernames to lowercase on write, allow case-insensitive lookups, and redirect to the canonical username.

--- a/app/api/feed/[id]/comments/[commentId]/like/route.ts
+++ b/app/api/feed/[id]/comments/[commentId]/like/route.ts
@@ -55,7 +55,6 @@ export async function POST(
     });
 
     let isLiked: boolean;
-    let likeCount: number;
 
     if (existingLike) {
       // Unlike the comment
@@ -80,11 +79,9 @@ export async function POST(
     }
 
     // Get updated like count
-    const updatedLikeCount = await prisma.commentLike.count({
+    const likeCount = await prisma.commentLike.count({
       where: { commentId }
     });
-
-    likeCount = updatedLikeCount;
 
     // Create notification if liking someone else's comment
     if (isLiked && comment.authorId !== userId) {

--- a/app/api/media/[id]/comments/[commentId]/like/route.ts
+++ b/app/api/media/[id]/comments/[commentId]/like/route.ts
@@ -47,7 +47,6 @@ export async function POST(
     })
 
     let isLiked: boolean
-    let likesCount: number
 
     if (existingLike) {
       // Unlike the comment
@@ -83,7 +82,7 @@ export async function POST(
       }
     })
 
-    likesCount = updatedComment?._count.likes || 0
+    const likesCount = updatedComment?._count.likes || 0
 
     return NextResponse.json({
       isLiked,

--- a/app/api/users/[id]/follow/route.ts
+++ b/app/api/users/[id]/follow/route.ts
@@ -52,8 +52,6 @@ export async function POST(
     })
 
     let isFollowing: boolean
-    let followersCount: number
-    let followingCount: number
 
     if (existingFollow) {
       // Unfollow
@@ -78,7 +76,7 @@ export async function POST(
     }
 
     // Get updated counts
-    const [followersCountResult, followingCountResult] = await Promise.all([
+    const [followersCount, followingCount] = await Promise.all([
       prisma.follow.count({
         where: { followingId: targetUserId }
       }),
@@ -86,9 +84,6 @@ export async function POST(
         where: { followerId: currentUserId }
       })
     ])
-
-    followersCount = followersCountResult
-    followingCount = followingCountResult
 
     return NextResponse.json({
       isFollowing,

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -18,20 +18,6 @@ const SearchPage: React.FC = () => {
   const [trendingSearches, setTrendingSearches] = useState<string[]>([]);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
 
-  // Skip database operations during build
-  const isBuildTime = typeof window === 'undefined' && process.env.NODE_ENV === 'production' && !process.env.DATABASE_URL?.includes('localhost');
-  
-  if (isBuildTime) {
-    return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-        <div className="max-w-4xl mx-auto px-4 py-8">
-          <h1 className="text-2xl font-bold mb-6">Search</h1>
-          <p>Loading...</p>
-        </div>
-      </div>
-    );
-  }
-
   // Get initial search parameters from URL
   const initialQuery = searchParams.get('q') || '';
   const initialType = (searchParams.get('type') as 'all' | 'users' | 'posts' | 'conversations') || 'all';
@@ -59,6 +45,20 @@ const SearchPage: React.FC = () => {
       }
     }
   }, []);
+
+  // Skip database operations during build
+  const isBuildTime = typeof window === 'undefined' && process.env.NODE_ENV === 'production' && !process.env.DATABASE_URL?.includes('localhost');
+
+  if (isBuildTime) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+        <div className="max-w-4xl mx-auto px-4 py-8">
+          <h1 className="text-2xl font-bold mb-6">Search</h1>
+          <p>Loading...</p>
+        </div>
+      </div>
+    );
+  }
 
   const handleResultSelect = (result: any) => {
     setSelectedResult(result);

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
         "jest": "^30.1.1",
         "jest-environment-jsdom": "^30.1.1",
         "nodemon": "^3.1.10",
-        "pg-mem": "^3.0.5",
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.4.1",
@@ -7120,25 +7119,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -7991,24 +7971,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
@@ -8101,13 +8063,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/discontinuous-range": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -9510,13 +9465,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9778,19 +9726,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -9946,13 +9881,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
       }
-    },
-    "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -10188,13 +10116,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11418,26 +11339,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
-      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "isarray": "^2.0.5",
-        "jsonify": "^0.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -11456,16 +11357,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
-      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
-      "dev": true,
-      "license": "Public Domain",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -11933,23 +11824,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moo": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/motion-dom": {
       "version": "12.23.12",
       "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
@@ -12069,36 +11943,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/nearley": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^2.19.0",
-        "moo": "^0.5.0",
-        "railroad-diagrams": "^1.0.0",
-        "randexp": "0.4.6"
-      },
-      "bin": {
-        "nearley-railroad": "bin/nearley-railroad.js",
-        "nearley-test": "bin/nearley-test.js",
-        "nearley-unparse": "bin/nearley-unparse.js",
-        "nearleyc": "bin/nearleyc.js"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://nearley.js.org/#give-to-nearley"
-      }
-    },
-    "node_modules/nearley/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12456,16 +12300,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -12789,106 +12623,6 @@
       "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
       "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
       "license": "MIT"
-    },
-    "node_modules/pg-mem": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.5.tgz",
-      "integrity": "sha512-Bh8xHD6u/wUXCoyFE2vyRs5pgaKbqjWFQowKDlbKWCiF0vOlo2A0PZdiUxmf2PKgb6Vb6C7gwAlA7jKvsfDHZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "functional-red-black-tree": "^1.0.1",
-        "immutable": "^4.3.4",
-        "json-stable-stringify": "^1.0.1",
-        "lru-cache": "^6.0.0",
-        "moment": "^2.27.0",
-        "object-hash": "^2.0.3",
-        "pgsql-ast-parser": "^12.0.1"
-      },
-      "peerDependencies": {
-        "@mikro-orm/core": ">=4.5.3",
-        "@mikro-orm/postgresql": ">=4.5.3",
-        "knex": ">=0.20",
-        "kysely": ">=0.26",
-        "pg-promise": ">=10.8.7",
-        "pg-server": "^0.1.5",
-        "postgres": "^3.4.4",
-        "slonik": ">=23.0.1",
-        "typeorm": ">=0.2.29"
-      },
-      "peerDependenciesMeta": {
-        "@mikro-orm/core": {
-          "optional": true
-        },
-        "@mikro-orm/postgresql": {
-          "optional": true
-        },
-        "knex": {
-          "optional": true
-        },
-        "kysely": {
-          "optional": true
-        },
-        "mikro-orm": {
-          "optional": true
-        },
-        "pg-promise": {
-          "optional": true
-        },
-        "pg-server": {
-          "optional": true
-        },
-        "postgres": {
-          "optional": true
-        },
-        "slonik": {
-          "optional": true
-        },
-        "typeorm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pg-mem/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pg-mem/node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/pg-mem/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/pgsql-ast-parser": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.1.tgz",
-      "integrity": "sha512-pe8C6Zh5MsS+o38WlSu18NhrTjAv1UNMeDTs2/Km2ZReZdYBYtwtbWGZKK2BM2izv5CrQpbmP0oI10wvHOwv4A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "moo": "^0.5.1",
-        "nearley": "^2.19.5"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -13310,27 +13044,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/railroad-diagrams": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "node_modules/randexp": {
-      "version": "0.4.6",
-      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "discontinuous-range": "1.0.0",
-        "ret": "~0.1.10"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -13721,16 +13434,6 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
-    "node_modules/ret": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -13968,24 +13671,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "jest": "^30.1.1",
     "jest-environment-jsdom": "^30.1.1",
     "nodemon": "^3.1.10",
-    "pg-mem": "^3.0.5",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29.4.1",


### PR DESCRIPTION
## Summary
- Drop pg-mem from tests and simulate case-insensitive username uniqueness with an in-memory Set
- Use const for count variables in like and follow API routes
- Ensure search page hooks always execute before build-time checks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8ac43a5cc8321bd06c4d100d6112b