### PR TITLE
fix: address useEffect dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Resolve multiple React Hook dependency warnings in profile, follower, workspace, notification, and toast components to ensure consistent state updates.
 - Replace pg-mem dependency in tests with an in-memory Set to simulate case-insensitive username uniqueness.
 - Use const declarations for like and follow counts in API routes and ensure `useEffect` runs consistently on the search page.
 - Show empty state with upload call-to-action on notes page and fix upload modal handling.

--- a/components/notifications/NotificationSettings.tsx
+++ b/components/notifications/NotificationSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -60,13 +60,7 @@ export function NotificationSettings({ className }: NotificationSettingsProps) {
     weekendQuietMode: false
   });
 
-  useEffect(() => {
-    if (session?.user) {
-      fetchPreferences();
-    }
-  }, [session]);
-
-  const fetchPreferences = async () => {
+  const fetchPreferences = useCallback(async () => {
     try {
       const response = await fetch('/api/notifications/preferences');
       const data = await response.json();
@@ -87,7 +81,13 @@ export function NotificationSettings({ className }: NotificationSettingsProps) {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (session?.user) {
+      fetchPreferences();
+    }
+  }, [session, fetchPreferences]);
 
   const getDefaultPreferences = (): NotificationPreference[] => [
     {

--- a/components/notifications/NotificationToast.tsx
+++ b/components/notifications/NotificationToast.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { X, Bell, CheckCircle, AlertCircle, Info, Star } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
@@ -80,6 +80,14 @@ export function NotificationToast({
   const config = typeConfig[type];
   const Icon = config.icon;
 
+  const handleClose = useCallback(() => {
+    setIsExiting(true);
+    setTimeout(() => {
+      setIsVisible(false);
+      onClose?.(id);
+    }, 300);
+  }, [id, onClose]);
+
   useEffect(() => {
     if (duration > 0) {
       const timer = setTimeout(() => {
@@ -88,15 +96,7 @@ export function NotificationToast({
 
       return () => clearTimeout(timer);
     }
-  }, [duration]);
-
-  const handleClose = () => {
-    setIsExiting(true);
-    setTimeout(() => {
-      setIsVisible(false);
-      onClose?.(id);
-    }, 300);
-  };
+  }, [duration, handleClose]);
 
   const handleAction = () => {
     onAction?.(id, actionUrl);

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -43,12 +43,16 @@ interface ToastProviderProps {
 export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
+  const removeToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id));
+  }, []);
+
   const addToast = useCallback((toast: Omit<Toast, 'id'>) => {
     const id = Math.random().toString(36).substr(2, 9);
     const newToast = { ...toast, id };
-    
+
     setToasts(prev => [...prev, newToast]);
-    
+
     // Auto remove after duration
     const duration = toast.duration ?? 5000;
     if (duration > 0) {
@@ -56,11 +60,7 @@ export const ToastProvider: React.FC<ToastProviderProps> = ({ children }) => {
         removeToast(id);
       }, duration);
     }
-  }, []);
-
-  const removeToast = useCallback((id: string) => {
-    setToasts(prev => prev.filter(toast => toast.id !== id));
-  }, []);
+  }, [removeToast]);
 
   const success = useCallback((title: string, description?: string, options?: Partial<Toast>) => {
     addToast({ ...options, type: 'success', title, description });

--- a/components/user/EnhancedProfile.tsx
+++ b/components/user/EnhancedProfile.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useSession } from 'next-auth/react';
 import { toast } from 'sonner';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
@@ -75,15 +75,11 @@ export function EnhancedProfile({ username, isOwnProfile = false }: EnhancedProf
   const [followersType, setFollowersType] = useState<'followers' | 'following'>('followers');
   const [activeTab, setActiveTab] = useState('posts');
 
-  useEffect(() => {
-    fetchProfile();
-  }, [username, session]);
-
-  const fetchProfile = async () => {
+  const fetchProfile = useCallback(async () => {
     try {
       setLoading(true);
-      const endpoint = isOwnProfile || !username 
-        ? '/api/users/profile' 
+      const endpoint = isOwnProfile || !username
+        ? '/api/users/profile'
         : `/api/users/${username}`;
       
       const response = await fetch(endpoint);
@@ -101,7 +97,11 @@ export function EnhancedProfile({ username, isOwnProfile = false }: EnhancedProf
     } finally {
       setLoading(false);
     }
-  };
+  }, [isOwnProfile, username]);
+
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile, session]);
 
   const handleFollow = async () => {
     if (!profile) return;

--- a/components/user/FollowersModal.tsx
+++ b/components/user/FollowersModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -48,26 +48,7 @@ export function FollowersModal({ userId, type, isOpen, onClose }: FollowersModal
   const [followingUsers, setFollowingUsers] = useState<Set<string>>(new Set());
   const [actionLoading, setActionLoading] = useState<Set<string>>(new Set());
 
-  useEffect(() => {
-    if (isOpen) {
-      fetchUsers();
-    }
-  }, [isOpen, userId, type]);
-
-  useEffect(() => {
-    // Filter users based on search query
-    if (searchQuery.trim()) {
-      const filtered = users.filter(user => 
-        user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        user.username.toLowerCase().includes(searchQuery.toLowerCase())
-      );
-      setFilteredUsers(filtered);
-    } else {
-      setFilteredUsers(users);
-    }
-  }, [searchQuery, users]);
-
-  const fetchUsers = async () => {
+  const fetchUsers = useCallback(async () => {
     try {
       setLoading(true);
       const response = await fetch(`/api/users/follow?userId=${userId}&type=${type}`);
@@ -76,7 +57,7 @@ export function FollowersModal({ userId, type, isOpen, onClose }: FollowersModal
       if (response.ok) {
         setUsers(data.users || []);
         setFilteredUsers(data.users || []);
-        
+
         // Track which users are being followed
         const following = new Set(
           data.users
@@ -93,7 +74,26 @@ export function FollowersModal({ userId, type, isOpen, onClose }: FollowersModal
     } finally {
       setLoading(false);
     }
-  };
+  }, [userId, type]);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchUsers();
+    }
+  }, [isOpen, fetchUsers]);
+
+  useEffect(() => {
+    // Filter users based on search query
+    if (searchQuery.trim()) {
+      const filtered = users.filter(user => 
+        user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        user.username.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+      setFilteredUsers(filtered);
+    } else {
+      setFilteredUsers(users);
+    }
+  }, [searchQuery, users]);
 
   const handleFollow = async (targetUserId: string, isCurrentlyFollowing: boolean) => {
     setActionLoading(prev => new Set(prev).add(targetUserId));

--- a/components/workspace/DocsView.tsx
+++ b/components/workspace/DocsView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -33,24 +33,22 @@ export function DocsView({ blockId }: DocsViewProps) {
   const [newPageTitle, setNewPageTitle] = useState('');
 
   // Fetch pages
-  const fetchPages = async () => {
+  const fetchPages = useCallback(async () => {
     try {
       const response = await fetch(`/api/workspace/docs/pages?blockId=${blockId}`);
       if (!response.ok) throw new Error('Failed to fetch pages');
-      
+
       const data = await response.json();
       setPages(data.pages);
-      
+
       // Set current page to first page if none selected
-      if (!currentPage && data.pages.length > 0) {
-        setCurrentPage(data.pages[0]);
-      }
+      setCurrentPage(prev => prev ?? data.pages[0] ?? null);
     } catch (error) {
       console.error('Error fetching pages:', error);
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [blockId]);
 
   // Create new page
   const createPage = async () => {
@@ -149,7 +147,7 @@ export function DocsView({ blockId }: DocsViewProps) {
 
   useEffect(() => {
     fetchPages();
-  }, [blockId]);
+  }, [fetchPages]);
 
   if (isLoading) {
     return (

--- a/components/workspace/FrasesView.tsx
+++ b/components/workspace/FrasesView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -29,11 +29,11 @@ export function FrasesView({ blockId }: FrasesViewProps) {
   const [editContent, setEditContent] = useState('');
 
   // Fetch items
-  const fetchItems = async () => {
+  const fetchItems = useCallback(async () => {
     try {
       const response = await fetch(`/api/workspace/frases/items?blockId=${blockId}`);
       if (!response.ok) throw new Error('Failed to fetch items');
-      
+
       const data = await response.json();
       setItems(data.items);
     } catch (error) {
@@ -41,7 +41,7 @@ export function FrasesView({ blockId }: FrasesViewProps) {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [blockId]);
 
   // Create item
   const createItem = async () => {
@@ -132,7 +132,7 @@ export function FrasesView({ blockId }: FrasesViewProps) {
 
   useEffect(() => {
     fetchItems();
-  }, [blockId]);
+  }, [fetchItems]);
 
   if (isLoading) {
     return (

--- a/components/workspace/KanbanView.tsx
+++ b/components/workspace/KanbanView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -46,11 +46,11 @@ export function KanbanView({ blockId }: KanbanViewProps) {
   const [editCardDescription, setEditCardDescription] = useState('');
 
   // Fetch columns
-  const fetchColumns = async () => {
+  const fetchColumns = useCallback(async () => {
     try {
       const response = await fetch(`/api/workspace/kanban/columns?blockId=${blockId}`);
       if (!response.ok) throw new Error('Failed to fetch columns');
-      
+
       const data = await response.json();
       setColumns(data.columns);
     } catch (error) {
@@ -58,7 +58,7 @@ export function KanbanView({ blockId }: KanbanViewProps) {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [blockId]);
 
   // Create column
   const createColumn = async () => {
@@ -234,7 +234,7 @@ export function KanbanView({ blockId }: KanbanViewProps) {
 
   useEffect(() => {
     fetchColumns();
-  }, [blockId]);
+  }, [fetchColumns]);
 
   if (isLoading) {
     return (

--- a/components/workspace/WorkspaceBlock.tsx
+++ b/components/workspace/WorkspaceBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useCallback } from 'react';
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -57,6 +57,23 @@ export function WorkspaceBlock({
   const blockRef = useRef<HTMLDivElement>(null);
 
   const Icon = BLOCK_ICONS[block.type];
+
+  const updateBlockOnServer = useCallback(async () => {
+    try {
+      await fetch(`/api/workspace/blocks/${block.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          x: block.x,
+          y: block.y,
+          w: block.w,
+          h: block.h,
+        }),
+      });
+    } catch (error) {
+      console.error('Error updating block:', error);
+    }
+  }, [block.id, block.x, block.y, block.w, block.h]);
 
   // Handle drag start
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -126,31 +143,13 @@ export function WorkspaceBlock({
     if (isDragging || isResizing) {
       document.addEventListener('mousemove', handleMouseMove);
       document.addEventListener('mouseup', handleMouseUp);
-      
+
       return () => {
         document.removeEventListener('mousemove', handleMouseMove);
         document.removeEventListener('mouseup', handleMouseUp);
       };
     }
-  }, [isDragging, isResizing, dragStart, resizeStart, block, onUpdate, zoom]);
-
-  // Update block on server
-  const updateBlockOnServer = async () => {
-    try {
-      await fetch(`/api/workspace/blocks/${block.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          x: block.x,
-          y: block.y,
-          w: block.w,
-          h: block.h,
-        }),
-      });
-    } catch (error) {
-      console.error('Error updating block:', error);
-    }
-  };
+  }, [isDragging, isResizing, dragStart, resizeStart, block, onUpdate, zoom, updateBlockOnServer]);
 
   // Handle delete
   const handleDelete = async () => {


### PR DESCRIPTION
## Summary
- handle useEffect dependencies in profile and follower components
- stabilize workspace components by wrapping server calls with `useCallback`
- clean up notification and toast hooks for reliable state updates

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8addfdcd4832185ba43e474f156be