### PR TITLE
Stub auth routes to return not implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Add aria-label to interest removal button for better accessibility.
 
 - Remove redundant Feed navigation item from sidebar and mobile menus.
-
+- Return 501 responses from placeholder auth API routes to prevent hanging requests.
 - Provide toast and loading components for events pages and coerce `page` and `limit` query parameters to numbers to avoid module resolution and validation errors.
 - Add missing events components and helpers so the events pages build without module resolution errors.
 - Default cart items to an empty array in `ShoppingCart` to prevent `reduce` on `undefined` errors when the cart is uninitialized.

--- a/api/routes/auth.ts
+++ b/api/routes/auth.ts
@@ -4,15 +4,14 @@
  */
 import { Router, type Request, type Response } from 'express';
 
-
 const router = Router();
 
 /**
- * User Login
+ * User Registration
  * POST /api/auth/register
  */
 router.post('/register', async (req: Request, res: Response): Promise<void> => {
-  // TODO: Implement register logic
+  res.status(501).json({ error: 'Not implemented' });
 });
 
 /**
@@ -20,7 +19,7 @@ router.post('/register', async (req: Request, res: Response): Promise<void> => {
  * POST /api/auth/login
  */
 router.post('/login', async (req: Request, res: Response): Promise<void> => {
-  // TODO: Implement login logic
+  res.status(501).json({ error: 'Not implemented' });
 });
 
 /**
@@ -28,7 +27,7 @@ router.post('/login', async (req: Request, res: Response): Promise<void> => {
  * POST /api/auth/logout
  */
 router.post('/logout', async (req: Request, res: Response): Promise<void> => {
-  // TODO: Implement logout logic
+  res.status(501).json({ error: 'Not implemented' });
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- return 501 responses from placeholder auth API routes so requests do not hang
- document auth route behavior in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8afaefecc83219d4576d8cb7b634e