### PR TITLE
Prevent self-follow actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Prevent users from following themselves in feed and marketplace interfaces.
 - Resolve multiple React Hook dependency warnings in profile, follower, workspace, notification, and toast components to ensure consistent state updates.
 - Replace pg-mem dependency in tests with an in-memory Set to simulate case-insensitive username uniqueness.
 - Use const declarations for like and follow counts in API routes and ensure `useEffect` runs consistently on the search page.

--- a/components/feed/PostList.tsx
+++ b/components/feed/PostList.tsx
@@ -28,6 +28,7 @@ import { FeedPost } from '@/types/feed';
 import { toast } from 'sonner';
 import CommentModal from './CommentModal';
 import { MediaViewer } from './MediaViewer';
+import { useSession } from 'next-auth/react';
 
 // Helper function to format time ago
 const formatTimeAgo = (dateString: string) => {
@@ -45,6 +46,7 @@ function PostCard({ post }: { post: FeedPost }) {
   const followUser = useFollowUser();
   const reportPost = useReportPost();
   const bookmarkPost = useBookmarkPost();
+  const { data: session } = useSession();
   const [showCommentModal, setShowCommentModal] = useState(false);
   const [showMediaViewer, setShowMediaViewer] = useState(false);
   const [selectedMediaIndex, setSelectedMediaIndex] = useState(0);
@@ -176,15 +178,17 @@ function PostCard({ post }: { post: FeedPost }) {
             @{post.author.username} • {formatTimeAgo(post.createdAt)}
           </p>
         </div>
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={handleFollow}
-          className="mr-2"
-          disabled={followUser.isPending}
-        >
-          Seguir
-        </Button>
+        {session?.user?.id !== post.author.id && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleFollow}
+            className="mr-2"
+            disabled={followUser.isPending}
+          >
+            Seguir
+          </Button>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" size="sm">

--- a/hooks/useEnhancedMarketplace.ts
+++ b/hooks/useEnhancedMarketplace.ts
@@ -364,6 +364,11 @@ export function useEnhancedMarketplace() {
       return false;
     }
 
+    if (sellerId === session.user.id) {
+      toast.error('No puedes seguirte a ti mismo');
+      return false;
+    }
+
     try {
       const response = await fetch(`/api/marketplace/sellers/${sellerId}/follow`, {
         method: 'POST',

--- a/tests/user-system.test.ts
+++ b/tests/user-system.test.ts
@@ -20,6 +20,12 @@ jest.mock('@/lib/prisma', () => ({
       findUnique: jest.fn(),
       findFirst: jest.fn(),
       create: jest.fn()
+    },
+    follow: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+      count: jest.fn()
     }
   }
 }))
@@ -56,6 +62,7 @@ jest.mock('@/lib/auth', () => ({
 import { POST as register } from '@/app/api/auth/register/route'
 import { GET as getOwnProfile } from '@/app/api/users/profile/route'
 import { GET as getUser } from '@/app/api/users/[id]/route'
+import { POST as followUser } from '@/app/api/users/[id]/follow/route'
 import ProfilePage from '@/app/u/[username]/page'
 import { getUserByUsername, getUserByEmail } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
@@ -151,4 +158,13 @@ test('DB enforces case-insensitive username uniqueness', () => {
   }
   insert('Juan')
   expect(() => insert('juan')).toThrow()
+})
+
+test('POST /api/users/[id]/follow prevents following yourself', async () => {
+  const userId = 'self';
+  getServerSessionNext.mockResolvedValueOnce({ user: { id: userId } });
+  const res = await followUser({} as any, { params: { id: userId } });
+  const json = await res.json();
+  expect(res.status).toBe(400);
+  expect(json.error).toBe('Cannot follow yourself');
 })


### PR DESCRIPTION
## Summary
- prevent following yourself in feed and marketplace hooks
- hide follow button on own posts
- test self-follow restriction and document in changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8b75090688321ba86db157eeae034