### PR TITLE
Enable inline profile editing with public view toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Use const declarations for like and follow counts in API routes and ensure `useEffect` runs consistently on the search page.
 - Show empty state with upload call-to-action on notes page and fix upload modal handling.
 - Allow creating workspace blocks in development and enable canvas panning by fixing block creation handler, updating block rendering with zoom, and ignoring pointer events on the grid.
+- Enable direct profile editing from `/<username>` with a "Vista pública" toggle and option to exit public view.
 - Normalize usernames to lowercase on write, allow case-insensitive lookups, and redirect to the canonical username.
 - Normalize emails to lowercase during registration and login to ensure account recognition after signing out.
 - Add `/api/users/profile` to fetch the authenticated user profile with stats.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ export default tseslint.config({
 - Global navigation now uses a single `MainLayout` from `app/layout.tsx`, ensuring the navbar is available throughout the site.
 - Various TypeScript errors were resolved and notification components were corrected for consistent behavior.
 - Gamification notifications are now categorized as `GAMIFICATION`, fixing local build errors.
+- El perfil se puede editar directamente desde `/<usuario>` con un botón "Vista pública" para alternar entre vista pública y edición.
 
 ### Patrón de notificaciones
 

--- a/app/[username]/edit/page.tsx
+++ b/app/[username]/edit/page.tsx
@@ -1,42 +1,9 @@
-import { getServerSession } from 'next-auth';
-import { notFound, redirect } from 'next/navigation';
-import { authOptions } from '@/lib/auth';
-import { ProfileView } from '@/components/profile/ProfileView';
-import { getUserByUsername, isReservedUsername } from '@/lib/users';
-import { USERNAME_REGEX } from '@/lib/validation';
-import type { Metadata } from 'next';
-
-export const metadata: Metadata = {
-  robots: { index: false },
-};
+import { redirect } from 'next/navigation';
 
 interface EditProfilePageProps {
   params: { username: string };
 }
 
-export default async function EditProfilePage({ params }: EditProfilePageProps) {
-  if (isReservedUsername(params.username) || !USERNAME_REGEX.test(params.username)) {
-    notFound();
-  }
-
-  const session = await getServerSession(authOptions);
-  const user = await getUserByUsername(params.username);
-
-  if (!user) {
-    notFound();
-  }
-
-  if (user.username !== params.username) {
-    redirect(`/${user.username}/edit`);
-  }
-
-  if (!session || session.user?.id !== user.id) {
-    redirect(`/${user.username}`);
-  }
-
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <ProfileView username={user.username} isOwnProfile={true} mode="edit" />
-    </div>
-  );
+export default function EditProfilePage({ params }: EditProfilePageProps) {
+  redirect(`/${params.username}`);
 }

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -89,7 +89,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
       <ProfileView
         username={user.username}
         isOwnProfile={isOwnProfile}
-        mode="public"
+        mode={isOwnProfile ? 'edit' : 'public'}
       />
     </div>
   );

--- a/components/user/EnhancedProfile.tsx
+++ b/components/user/EnhancedProfile.tsx
@@ -74,6 +74,11 @@ export function EnhancedProfile({ username, isOwnProfile = false, mode = 'public
   const [showFollowers, setShowFollowers] = useState(false);
   const [followersType, setFollowersType] = useState<'followers' | 'following'>('followers');
   const [activeTab, setActiveTab] = useState('posts');
+  const [viewMode, setViewMode] = useState<'public' | 'edit'>(mode);
+
+  useEffect(() => {
+    setViewMode(mode);
+  }, [mode]);
 
   const fetchProfile = useCallback(async () => {
     try {
@@ -278,19 +283,28 @@ export function EnhancedProfile({ username, isOwnProfile = false, mode = 'public
             {/* Action Buttons */}
             <div className="flex gap-2">
               {isOwnProfile ? (
-                mode === 'public' ? (
-                  <Button onClick={() => (window.location.href = `/${profile.username}/edit`)} aria-label="Editar perfil">
-                    <Edit3 className="w-4 h-4 mr-2" />
-                    Editar perfil
-                  </Button>
+                viewMode === 'edit' ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      onClick={() => setViewMode('public')}
+                      aria-label="Vista pública"
+                    >
+                      Vista pública
+                    </Button>
+                    <Button onClick={() => setShowEditor(true)} aria-label="Editar perfil">
+                      <Edit3 className="w-4 h-4 mr-2" />
+                      Editar perfil
+                    </Button>
+                  </>
                 ) : (
                   <>
                     <Button
                       variant="outline"
-                      onClick={() => (window.location.href = `/${profile.username}`)}
-                      aria-label="Ver público"
+                      onClick={() => setViewMode('edit')}
+                      aria-label="Salir de vista pública"
                     >
-                      Ver público
+                      Salir de vista pública
                     </Button>
                     <Button onClick={() => setShowEditor(true)} aria-label="Editar perfil">
                       <Edit3 className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- allow profile editing directly from `/<username>`
- add `Vista pública` toggle with option to exit public view
- document profile editing flow in README and changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9384588cc83218c13b664b7a7d04e