### PR TITLE
Evita error de toLocaleString en ProfileView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Evita errores de `toLocaleString` en `ProfileView` cuando los contadores de seguidores, seguidos o publicaciones no están definidos.
 - Prevent users from following themselves in feed and marketplace interfaces.
 - Resolve multiple React Hook dependency warnings in profile, follower, workspace, notification, and toast components to ensure consistent state updates.
 - Replace pg-mem dependency in tests with an in-memory Set to simulate case-insensitive username uniqueness.

--- a/components/profile/ProfileView.tsx
+++ b/components/profile/ProfileView.tsx
@@ -60,9 +60,9 @@ interface UserProfile {
   website?: string;
   joinDate: string;
   isVerified?: boolean;
-  followers: number;
-  following: number;
-  posts: number;
+  followers?: number;
+  following?: number;
+  posts?: number;
   isFollowing?: boolean;
   socialLinks?: {
     twitter?: string;
@@ -286,19 +286,19 @@ export function ProfileView({ username, isOwnProfile, mode }: ProfileViewProps) 
                   className="text-center hover:text-blue-500 transition-colors"
                 >
                   <div className="font-bold text-gray-900 dark:text-gray-100">
-                    {userProfile.followers.toLocaleString()}
+                    {(userProfile.followers ?? 0).toLocaleString()}
                   </div>
                   <div className="text-sm text-gray-600 dark:text-gray-400">Seguidores</div>
                 </button>
                 <button className="text-center hover:text-blue-500 transition-colors">
                   <div className="font-bold text-gray-900 dark:text-gray-100">
-                    {userProfile.following.toLocaleString()}
+                    {(userProfile.following ?? 0).toLocaleString()}
                   </div>
                   <div className="text-sm text-gray-600 dark:text-gray-400">Siguiendo</div>
                 </button>
                 <div className="text-center">
                   <div className="font-bold text-gray-900 dark:text-gray-100">
-                    {userProfile.posts.toLocaleString()}
+                    {(userProfile.posts ?? 0).toLocaleString()}
                   </div>
                   <div className="text-sm text-gray-600 dark:text-gray-400">Posts</div>
                 </div>

--- a/components/social/FollowList.tsx
+++ b/components/social/FollowList.tsx
@@ -85,7 +85,7 @@ export function FollowList({
   const currentList = activeTab === 'followers' ? followers : following;
 
   const filteredAndSortedUsers = useMemo(() => {
-    let filtered = currentList.filter(user => {
+    const filtered = currentList.filter(user => {
       // Search filter
       const matchesSearch = 
         user.name.toLowerCase().includes(searchQuery.toLowerCase()) ||


### PR DESCRIPTION
## Resumen
- Maneja contadores de seguidores, seguidos y publicaciones cuando faltan para evitar fallos de `toLocaleString`
- Ajusta `FollowList` para cumplir con ESLint
- Documenta la corrección en el `CHANGELOG`

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b946a155d88321b75a159ac23cb134