### PR TITLE
Redirect profile route to user slug and show public view by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Remove legacy `/perfil` route and update navigation to use `/{username}` paths.
+- Redirect `/profile` to `/{username}` and open profiles in public view instead of edit mode.
 - Evita errores de `toLocaleString` en `ProfileView` cuando los contadores de seguidores, seguidos o publicaciones no están definidos.
 - Prevent users from following themselves in feed and marketplace interfaces.
 - Resolve multiple React Hook dependency warnings in profile, follower, workspace, notification, and toast components to ensure consistent state updates.

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -89,7 +89,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
       <ProfileView
         username={user.username}
         isOwnProfile={isOwnProfile}
-        mode={isOwnProfile ? 'edit' : 'public'}
+        mode="public"
       />
     </div>
   );

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,7 +2,6 @@ import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { EnhancedProfile } from '@/components/user/EnhancedProfile';
 
 export const metadata: Metadata = {
   title: 'Mi Perfil - CRUNEVO',
@@ -11,14 +10,10 @@ export const metadata: Metadata = {
 
 export default async function MyProfilePage() {
   const session = await getServerSession(authOptions);
-  
+
   if (!session?.user) {
     redirect('/auth/signin');
   }
-
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <EnhancedProfile isOwnProfile={true} />
-    </div>
-  );
+  // Redirect to the user's public profile instead of rendering the edit view
+  redirect(`/${session.user.username}`);
 }

--- a/app/profile/settings/page.tsx
+++ b/app/profile/settings/page.tsx
@@ -211,7 +211,7 @@ export default function ProfileSettingsPage() {
                 )}
                 
                 <Button variant="outline" asChild>
-                  <Link href="/profile">
+                  <Link href={`/${session?.user?.username ?? ''}`}>
                     <User className="h-4 w-4 mr-2" />
                     Ver Perfil Público
                   </Link>


### PR DESCRIPTION
## Summary
- redirect `/profile` to `/{username}` instead of rendering edit view
- open own profile in public mode by default
- update settings link to point to public profile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb56e0dfac8321bff12f61388713ec