### PR TITLE
feat(workspace): include board owner in responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Include board creator in workspace board responses so "Gestionar Colaboradores" shows the owner.
 - Remove legacy `/perfil` route and update navigation to use `/{username}` paths.
 - Redirect `/profile` to `/{username}` and open profiles in public view instead of edit mode.
 - Evita errores de `toLocaleString` en `ProfileView` cuando los contadores de seguidores, seguidos o publicaciones no están definidos.

--- a/app/api/workspace/boards/[boardId]/route.ts
+++ b/app/api/workspace/boards/[boardId]/route.ts
@@ -18,6 +18,9 @@ export async function GET(req: Request, { params }: { params: Promise<{ boardId:
     const board = await prisma.workspaceBoard.findFirst({
       where: { id: boardId, userId: session.user.id },
       include: {
+        user: {
+          select: { id: true, name: true, email: true, image: true }
+        },
         blocks: {
           include: {
             docsPages: true,
@@ -30,7 +33,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ boardId:
     if (!board) {
       return Response.json({ error: 'Not found' }, { status: 404 });
     }
-    return Response.json({ board });
+    return Response.json({ board: { ...board, owner: board.user } });
   } catch (e) {
     console.error('[GET /api/workspace/boards/:id]', e);
     return Response.json({ error: 'Internal error' }, { status: 500 });


### PR DESCRIPTION
## Summary
- include board creator in workspace board responses
- expose owner on board lookup for collaborator manager
- document workspace board owner in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb591e37648321a7114ce23689a597