### PR TITLE
Show workspace board creator in collaborator manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Initialize default content and unique z-index when creating workspace blocks so new blocks render reliably.
 - Provide board management API routes to update, delete and duplicate boards, enabling workspace configuration.
 - Remove placeholder random values from workspace statistics and expose collaborator and shared board counts.
+- Include board creator details in workspace board API responses so the owner appears in the collaborator manager.
 
 - Align feed client with API pagination and add single post endpoint for local development.
 - Improve feed post actions: link user names to profiles, move follow button beside author info, restore flame reaction, and add share handling.

--- a/app/api/workspace/boards/[boardId]/route.ts
+++ b/app/api/workspace/boards/[boardId]/route.ts
@@ -18,6 +18,7 @@ export async function GET(req: Request, { params }: { params: Promise<{ boardId:
     const board = await prisma.workspaceBoard.findFirst({
       where: { id: boardId, userId: session.user.id },
       include: {
+        user: { select: { id: true, name: true, email: true, image: true } },
         blocks: {
           include: {
             docsPages: true,
@@ -30,7 +31,8 @@ export async function GET(req: Request, { params }: { params: Promise<{ boardId:
     if (!board) {
       return Response.json({ error: 'Not found' }, { status: 404 });
     }
-    return Response.json({ board });
+    const { user, ...rest } = board as any;
+    return Response.json({ board: { ...rest, owner: user } });
   } catch (e) {
     console.error('[GET /api/workspace/boards/:id]', e);
     return Response.json({ error: 'Internal error' }, { status: 500 });
@@ -62,8 +64,12 @@ export async function PUT(req: Request, { params }: { params: Promise<{ boardId:
     const board = await prisma.workspaceBoard.update({
       where: { id: boardId },
       data,
+      include: {
+        user: { select: { id: true, name: true, email: true, image: true } }
+      }
     });
-    return Response.json({ board });
+    const { user, ...rest } = board as any;
+    return Response.json({ board: { ...rest, owner: user } });
   } catch (e) {
     console.error('[PUT /api/workspace/boards/:id]', e);
     return Response.json({ error: 'Internal error' }, { status: 500 });

--- a/app/api/workspace/boards/route.ts
+++ b/app/api/workspace/boards/route.ts
@@ -18,6 +18,9 @@ export async function GET(req: Request) {
       where: { userId: session.user.id },
       orderBy: { createdAt: 'asc' },
       include: {
+        user: {
+          select: { id: true, name: true, email: true, image: true }
+        },
         blocks: {
           include: {
             docsPages: true,
@@ -32,6 +35,9 @@ export async function GET(req: Request) {
       const created = await prisma.workspaceBoard.create({
         data: { userId: session.user.id, name: 'Pizarra 1', isDefault: true },
         include: {
+          user: {
+            select: { id: true, name: true, email: true, image: true }
+          },
           blocks: {
             include: {
               docsPages: true,
@@ -41,9 +47,12 @@ export async function GET(req: Request) {
           }
         }
       });
-      return Response.json({ boards: [created], defaultBoard: created.id });
+      const createdBoard = { ...created, owner: created.user } as any;
+      delete createdBoard.user;
+      return Response.json({ boards: [createdBoard], defaultBoard: created.id });
     }
-    return Response.json({ boards, defaultBoard });
+    const formatted = boards.map(({ user, ...rest }) => ({ ...rest, owner: user }));
+    return Response.json({ boards: formatted, defaultBoard });
   } catch (e) {
     console.error('[GET /api/workspace/boards]', e);
     return Response.json({ error: 'Internal error' }, { status: 500 });
@@ -60,9 +69,12 @@ export async function POST(req: Request) {
     }
     const { name } = await req.json();
     const board = await prisma.workspaceBoard.create({
-      data: { userId: session.user.id, name: name || 'Pizarra 1', isDefault: false }
+      data: { userId: session.user.id, name: name || 'Pizarra 1', isDefault: false },
+      include: {
+        user: { select: { id: true, name: true, email: true, image: true } }
+      }
     });
-    return Response.json({ board }, { status: 201 });
+    return Response.json({ board: { ...board, owner: board.user } }, { status: 201 });
   } catch (e) {
     console.error('[POST /api/workspace/boards]', e);
     return Response.json({ error: 'Internal error' }, { status: 500 });


### PR DESCRIPTION
## Summary
- include board owner details in workspace board API responses so the creator appears when managing collaborators
- expose owner info from backend service for board listing and retrieval
- document change in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb591e37648321a7114ce23689a597