### PR TITLE
Conectar /notes con API y habilitar subida de apuntes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ export default tseslint.config({
 - Various TypeScript errors were resolved and notification components were corrected for consistent behavior.
 - Gamification notifications are now categorized as `GAMIFICATION`, fixing local build errors.
 - El perfil se puede editar directamente desde `/<usuario>` con un botón "Vista pública" para alternar entre vista pública y edición.
+- `/notes` ahora carga apuntes desde la API y el modal de "Subir Apunte" crea apuntes reales mediante `/api/notes`.
 
 ### Patrón de notificaciones
 

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { Search, Filter, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -82,11 +83,11 @@ export default function NotesPage() {
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedCareer, setSelectedCareer] = useState('');
   const [sortBy, setSortBy] = useState('recent');
+  const queryClient = useQueryClient();
 
   // Manejar el éxito del formulario de carga de apuntes
-  const handleUploadSuccess = (noteData: any) => {
-    // En un escenario real se debería actualizar la lista de apuntes
-    console.log('Apunte subido', noteData);
+  const handleUploadSuccess = () => {
+    queryClient.invalidateQueries({ queryKey: ['notes'] });
   };
 
   const handleNoteSelect = (noteId: string) => {

--- a/hooks/useNotes.ts
+++ b/hooks/useNotes.ts
@@ -71,7 +71,8 @@ export function useNotes(filters: NotesFilters = {}) {
       if (!response.ok) {
         throw new Error('Failed to fetch notes');
       }
-      return response.json();
+      const data = await response.json();
+      return data.notes;
     },
     staleTime: 5 * 60 * 1000, // 5 minutes
   });


### PR DESCRIPTION
## Summary
- Integrate `/notes` page with React Query invalidation to refresh notes after uploads
- Send upload modal data to `/api/notes` with form submission and feedback
- Adjust notes hook to consume API `notes` payload and document change in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb5a750adc8321ab1850d282ed12b0