### PR TITLE
fix: guard profile feed numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Normalize profile feed response to a posts array to prevent `filteredItems.map` runtime errors in `ProfileFeed`.
+- Evita errores de `toString` en `ProfileFeed` cuando las estadísticas no están definidas.
 - Keep profile data in sync in the edit dialog by updating local state and resetting form values on open.
 - Remove legacy `/perfil` route and update navigation to use `/{username}` paths.
 - Redirect `/profile` to `/{username}` and open profiles in public view instead of edit mode.

--- a/components/profile/ProfileFeed.tsx
+++ b/components/profile/ProfileFeed.tsx
@@ -139,7 +139,11 @@ const getTypeLabel = (type: FeedItem['type']) => {
 
 
 
-const formatNumber = (num: number): string => {
+// Format numeric stats and guard against undefined values
+const formatNumber = (num?: number | null): string => {
+  if (typeof num !== 'number' || isNaN(num)) {
+    return '0';
+  }
   if (num >= 1000) {
     return (num / 1000).toFixed(1) + 'K';
   }


### PR DESCRIPTION
## Summary
- avoid toString on undefined stats in profile feed
- document fix in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb5bec72608321b5a1b18ce4b905eb