### PR TITLE
fix: handle undefined in formatNumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Evita errores de `toString` en `ProfileFeed` al manejar valores indefinidos en `formatNumber`.
 - Normalize profile feed response to a posts array to prevent `filteredItems.map` runtime errors in `ProfileFeed`.
 - Keep profile data in sync in the edit dialog by updating local state and resetting form values on open.
 - Remove legacy `/perfil` route and update navigation to use `/{username}` paths.

--- a/components/profile/ProfileFeed.tsx
+++ b/components/profile/ProfileFeed.tsx
@@ -139,7 +139,14 @@ const getTypeLabel = (type: FeedItem['type']) => {
 
 
 
-const formatNumber = (num: number): string => {
+/**
+ * Formats a numeric value for display.
+ * Safely handles undefined or non-numeric inputs by returning "0".
+ */
+const formatNumber = (num?: number): string => {
+  if (typeof num !== 'number' || isNaN(num)) {
+    return '0';
+  }
   if (num >= 1000) {
     return (num / 1000).toFixed(1) + 'K';
   }


### PR DESCRIPTION
## Summary
- guard `formatNumber` against undefined values
- document fix in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb5bec72608321b5a1b18ce4b905eb