### PR TITLE
feat: support @username routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Replace user profile paths from `/u/{username}` to `/@{username}` and redirect old URLs.
 - Evita errores de `toString` en `ProfileFeed` al manejar valores indefinidos en `formatNumber`.
 - Normalize profile feed response to a posts array to prevent `filteredItems.map` runtime errors in `ProfileFeed`.
 - Keep profile data in sync in the edit dialog by updating local state and resetting form values on open.

--- a/app/u/[username]/page.tsx
+++ b/app/u/[username]/page.tsx
@@ -53,7 +53,7 @@ export async function generateMetadata({ params }: ParamP): Promise<Metadata> {
         images: user.image ? [user.image] : []
       },
       alternates: {
-        canonical: `/u/${user.username}`
+        canonical: `/@${user.username}`
       }
     };
   } catch (error) {
@@ -79,7 +79,7 @@ export default async function ProfilePage({ params }: ParamP) {
   }
 
   if (user.username !== username) {
-    redirect(`/u/${user.username}`);
+    redirect(`/@${user.username}`);
   }
 
   const isOwnProfile = session?.user?.id === user.id;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,23 @@ const nextConfig = {
   images: {
     remotePatterns: [{ protocol: 'https', hostname: '**' }],
   },
+  async rewrites() {
+    return [
+      {
+        source: '/@:username',
+        destination: '/u/:username',
+      },
+    ];
+  },
+  async redirects() {
+    return [
+      {
+        source: '/u/:username',
+        destination: '/@:username',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/tests/user-system.test.ts
+++ b/tests/user-system.test.ts
@@ -100,7 +100,7 @@ test('getUserByUsername matches case-insensitively', async () => {
 
 test('GET /ROGGER redirects to canonical lowercase', async () => {
   prismaMock.findFirst.mockResolvedValue({ id: '1', username: 'rogger' })
-  await expect(ProfilePage({ params: { username: 'ROGGER' } })).rejects.toThrow('REDIRECT:/u/rogger')
+  await expect(ProfilePage({ params: { username: 'ROGGER' } })).rejects.toThrow('REDIRECT:/@rogger')
 })
 
 test('GET /api/users/[id] returns profile for uppercase username', async () => {


### PR DESCRIPTION
## Summary
- rewrite `/:username` profile URLs to use `@` prefix
- update profile metadata and tests for new path
- document profile URL change

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bccdef570083219b33dfd3bb589052