### PR TITLE
Support @username URLs for profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Permite acceder a perfiles de usuario mediante rutas `/@usuario` y reemplaza prefijos `/u/`.
 - Evita errores de `toString` en `ProfileFeed` al manejar valores indefinidos en `formatNumber`.
 - Normalize profile feed response to a posts array to prevent `filteredItems.map` runtime errors in `ProfileFeed`.
 - Keep profile data in sync in the edit dialog by updating local state and resetting form values on open.

--- a/app/u/[username]/page.tsx
+++ b/app/u/[username]/page.tsx
@@ -16,7 +16,8 @@ export async function generateMetadata({ params }: ParamP): Promise<Metadata> {
   if (process.env.NODE_ENV === 'production' && !process.env.DATABASE_URL?.includes('localhost')) {
     return {
       title: `@${username} - CRUNEVO`,
-      description: `Perfil de ${username} en CRUNEVO`
+      description: `Perfil de ${username} en CRUNEVO`,
+      alternates: { canonical: `/@${username}` }
     };
   }
 
@@ -53,13 +54,14 @@ export async function generateMetadata({ params }: ParamP): Promise<Metadata> {
         images: user.image ? [user.image] : []
       },
       alternates: {
-        canonical: `/u/${user.username}`
+        canonical: `/@${user.username}`
       }
     };
   } catch (error) {
     return {
       title: `@${username} - CRUNEVO`,
-      description: `Perfil de ${username} en CRUNEVO`
+      description: `Perfil de ${username} en CRUNEVO`,
+      alternates: { canonical: `/@${username}` }
     };
   }
 }
@@ -79,7 +81,7 @@ export default async function ProfilePage({ params }: ParamP) {
   }
 
   if (user.username !== username) {
-    redirect(`/u/${user.username}`);
+    redirect(`/@${user.username}`);
   }
 
   const isOwnProfile = session?.user?.id === user.id;

--- a/next.config.js
+++ b/next.config.js
@@ -35,7 +35,10 @@ const nextConfig = {
   },
   // Disable static optimization for problematic pages
   async rewrites() {
-    return [];
+    return [
+      { source: '/@:username', destination: '/u/:username' },
+      { source: '/@:username/:path*', destination: '/u/:username/:path*' },
+    ];
   },
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,12 @@ const nextConfig = {
   images: {
     remotePatterns: [{ protocol: 'https', hostname: '**' }],
   },
+  async rewrites() {
+    return [
+      { source: '/@:username', destination: '/u/:username' },
+      { source: '/@:username/:path*', destination: '/u/:username/:path*' },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/tests/user-system.test.ts
+++ b/tests/user-system.test.ts
@@ -100,7 +100,7 @@ test('getUserByUsername matches case-insensitively', async () => {
 
 test('GET /ROGGER redirects to canonical lowercase', async () => {
   prismaMock.findFirst.mockResolvedValue({ id: '1', username: 'rogger' })
-  await expect(ProfilePage({ params: { username: 'ROGGER' } })).rejects.toThrow('REDIRECT:/u/rogger')
+  await expect(ProfilePage({ params: { username: 'ROGGER' } })).rejects.toThrow('REDIRECT:/@rogger')
 })
 
 test('GET /api/users/[id] returns profile for uppercase username', async () => {


### PR DESCRIPTION
## Summary
- route `/@usuario` to existing profile pages and subpaths
- canonical profile links and redirects now use `@username`
- document new profile URL format in changelog

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bccdef570083219b33dfd3bb589052