### PR TITLE
Rebuild profile editor with tabbed form and live preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Reconstruye el modal de edición de perfil con pestañas, vista previa en vivo y botón de cierre único.
 - Permite acceder a perfiles de usuario mediante rutas `/@usuario` y reemplaza prefijos `/u/`.
 - Evita errores de `toString` en `ProfileFeed` al manejar valores indefinidos en `formatNumber`.
 - Normalize profile feed response to a posts array to prevent `filteredItems.map` runtime errors in `ProfileFeed`.

--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "./button";
+import { Popover, PopoverTrigger, PopoverContent } from "./popover";
+import { Input } from "./input";
+import { ScrollArea } from "./scroll-area";
+import { cn } from "@/lib/utils";
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface ComboboxProps {
+  value?: string;
+  onChange: (value: string) => void;
+  options: Option[];
+  placeholder?: string;
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function Combobox({
+  value,
+  onChange,
+  options,
+  placeholder = "Seleccione...",
+  emptyMessage = "No hay opciones",
+  className,
+}: ComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const filtered = options.filter((opt) =>
+    opt.label.toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={cn("w-full justify-between", className)}
+        >
+          {value ? options.find((o) => o.value === value)?.label : placeholder}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="p-0" align="start">
+        <div className="p-2">
+          <Input
+            placeholder="Buscar..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <ScrollArea className="h-48">
+          {filtered.length ? (
+            <ul className="p-1">
+              {filtered.map((opt) => (
+                <li key={opt.value}>
+                  <button
+                    type="button"
+                    className={cn(
+                      "w-full text-left p-2 rounded hover:bg-muted",
+                      value === opt.value && "bg-muted"
+                    )}
+                    onClick={() => {
+                      onChange(opt.value);
+                      setOpen(false);
+                      setSearch("");
+                    }}
+                  >
+                    {opt.label}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <div className="p-2 text-sm text-muted-foreground">
+              {emptyMessage}
+            </div>
+          )}
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default Combobox;


### PR DESCRIPTION
## Summary
- rebuild profile editor modal with basic/social/privacidad tabs, avatar upload and live preview
- add reusable combobox component for searchable dropdowns
- document profile editor rebuild in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bccf284e3083219a1a8e55a3635754