### PR TITLE
Use @username paths in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Reconstruye el modal de edición de perfil con pestañas, vista previa en vivo y botón de cierre único.
 - Permite acceder a perfiles de usuario mediante rutas `/@usuario` y reemplaza prefijos `/u/`.
+- Actualiza menús y barras de navegación para enlazar a perfiles usando `/@usuario`.
 - Evita errores de `toString` en `ProfileFeed` al manejar valores indefinidos en `formatNumber`.
 - Normalize profile feed response to a posts array to prevent `filteredItems.map` runtime errors in `ProfileFeed`.
 - Keep profile data in sync in the edit dialog by updating local state and resetting form values on open.

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -15,5 +15,5 @@ export default async function MyProfilePage() {
     redirect('/auth/signin');
   }
   // Redirect to the user's public profile instead of rendering the edit view
-  redirect(`/${session.user.username}`);
+  redirect(`/@${session.user.username}`);
 }

--- a/app/profile/settings/page.tsx
+++ b/app/profile/settings/page.tsx
@@ -211,7 +211,7 @@ export default function ProfileSettingsPage() {
                 )}
                 
                 <Button variant="outline" asChild>
-                  <Link href={`/${session?.user?.username ?? ''}`}>
+                  <Link href={`/@${session?.user?.username ?? ''}`}>
                     <User className="h-4 w-4 mr-2" />
                     Ver Perfil Público
                   </Link>

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -66,7 +66,7 @@ const SearchPage: React.FC = () => {
     // Navigate based on result type
     if (result.username) {
       // User result
-      router.push(`/${result.username}`);
+      router.push(`/@${result.username}`);
     } else if (result.content) {
       // Post result
       router.push(`/post/${result.id}`);

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -211,7 +211,7 @@ export default function SettingsPage() {
           <p className="text-gray-600">Error loading settings</p>
           <Button
             onClick={() =>
-              router.push(`/${(session?.user as any)?.username || ''}`)
+              router.push(`/@${(session?.user as any)?.username || ''}`)
             }
             className="mt-4"
           >
@@ -231,7 +231,7 @@ export default function SettingsPage() {
             variant="ghost"
             size="sm"
             onClick={() =>
-              router.push(`/${(session?.user as any)?.username || ''}`)
+              router.push(`/@${(session?.user as any)?.username || ''}`)
             }
             className="flex items-center gap-2"
           >

--- a/app/u/[username]/edit/page.tsx
+++ b/app/u/[username]/edit/page.tsx
@@ -5,5 +5,5 @@ interface EditProfilePageProps {
 }
 
 export default function EditProfilePage({ params }: EditProfilePageProps) {
-  redirect(`/${params.username}`);
+  redirect(`/@${params.username}`);
 }

--- a/components/feed/PostList.tsx
+++ b/components/feed/PostList.tsx
@@ -153,7 +153,7 @@ function PostCard({ post }: { post: FeedPost }) {
     <Card className="p-6 hover:shadow-md transition-shadow">
       {/* Header del post */}
       <div className="flex items-start space-x-3 mb-4">
-        <Link href={`/${post.author.username}`} className="h-10 w-10">
+        <Link href={`/@${post.author.username}`} className="h-10 w-10">
           <Avatar className="h-10 w-10">
             <img
               src={post.author.avatar || '/default-avatar.png'}
@@ -164,7 +164,7 @@ function PostCard({ post }: { post: FeedPost }) {
         </Link>
         <div className="flex-1 min-w-0">
           <div className="flex items-center space-x-2">
-            <Link href={`/${post.author.username}`} className="hover:underline">
+            <Link href={`/@${post.author.username}`} className="hover:underline">
               <h3 className="font-semibold text-sm truncate">{post.author.name}</h3>
             </Link>
             <span className="text-xs">{getPostIcon()}</span>

--- a/components/layout/MobileNavbar.tsx
+++ b/components/layout/MobileNavbar.tsx
@@ -69,7 +69,7 @@ export function MobileNavbar({ isOpen, onClose }: MobileNavbarProps) {
       return {
         ...item,
         href: session?.user
-          ? `/${(session.user as any).username}`
+          ? `/@${(session.user as any).username}`
           : '/auth/login',
       };
     }
@@ -77,7 +77,7 @@ export function MobileNavbar({ isOpen, onClose }: MobileNavbarProps) {
       return {
         ...item,
         href: session?.user
-          ? `/${(session.user as any).username}/gamification`
+          ? `/@${(session.user as any).username}/gamification`
           : '/auth/login',
       };
     }
@@ -224,7 +224,7 @@ export function MobileNavbar({ isOpen, onClose }: MobileNavbarProps) {
               <div className="flex-1">
                 <p className="font-semibold text-gray-900 dark:text-white">{session.user?.name}</p>
                 <Link
-                  href={session?.user ? `/${(session.user as any).username}` : '/auth/login'}
+                  href={session?.user ? `/@${(session.user as any).username}` : '/auth/login'}
                   onClick={closeDrawer}
                   className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
                 >

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -110,7 +110,7 @@ export function Navbar() {
                     <DropdownMenuSeparator />
                     <DropdownMenuItem asChild>
                       <Link
-                        href={session?.user ? `/${(session.user as any).username}` : '/auth/login'}
+                        href={session?.user ? `/@${(session.user as any).username}` : '/auth/login'}
                         className="flex items-center"
                       >
                         <User className="mr-2 h-4 w-4" />

--- a/components/layout/Navigation.tsx
+++ b/components/layout/Navigation.tsx
@@ -75,7 +75,7 @@ export function Navigation({ session, onMenuClick }: NavigationProps) {
                   </div>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem asChild>
-                    <Link href={`/${(session?.user as any)?.username || ''}`}>
+                    <Link href={`/@${(session?.user as any)?.username || ''}`}>
                       <User className="mr-2 h-4 w-4" />
                       <span>Perfil</span>
                     </Link>

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -70,7 +70,7 @@ export function Sidebar() {
     { name: 'Inicio', href: '/', icon: Home },
     {
       name: 'Perfil',
-      href: session?.user ? `/${(session.user as any).username}` : '/auth/login',
+      href: session?.user ? `/@${(session.user as any).username}` : '/auth/login',
       icon: User,
     },
     { name: 'Workspace', href: '/workspace', icon: Grid3X3, color: 'text-crunevo-600' },
@@ -86,7 +86,7 @@ export function Sidebar() {
     {
       name: 'Gamificación',
       href: session?.user
-        ? `/${(session.user as any).username}/gamification`
+        ? `/@${(session.user as any).username}/gamification`
         : '/auth/login',
       icon: Zap,
       color: 'text-crunevo-600',

--- a/components/perfil/ProfileEditor.tsx
+++ b/components/perfil/ProfileEditor.tsx
@@ -190,7 +190,7 @@ export default function ProfileEditor({ profile, onSave, onCancel }: ProfileEdit
   const handleViewPublic = () => {
     // Extract username from email or use a default
     const username = formData.email?.split('@')[0] || 'usuario'
-    router.push(`/${username}`)
+    router.push(`/@${username}`)
   }
 
   return (

--- a/components/perfil/ProfileHeader.tsx
+++ b/components/perfil/ProfileHeader.tsx
@@ -183,7 +183,7 @@ export function ProfileHeader({ user, mode, onEdit, onViewPublic, onBannerChange
                         if (onViewPublic) {
                           onViewPublic()
                         } else {
-                          router.push(`/${user.username}`)
+                          router.push(`/@${user.username}`)
                         }
                       }}
                     >

--- a/components/perfil/SocialProfile.tsx
+++ b/components/perfil/SocialProfile.tsx
@@ -127,7 +127,7 @@ export function SocialProfile({ user, isOwnProfile = false }: SocialProfileProps
         }}
         mode={isOwnProfile ? 'view' : 'public'}
         onEdit={() => setShowEditor(true)}
-        onViewPublic={() => router.push(`/${profileData.username}`)}
+        onViewPublic={() => router.push(`/@${profileData.username}`)}
         onBannerChange={(newBanner) => setBannerImage(newBanner)}
         onAvatarChange={(newAvatar) => setProfileImage(newAvatar)}
       />

--- a/components/sidebar/UserMiniCard.tsx
+++ b/components/sidebar/UserMiniCard.tsx
@@ -8,7 +8,7 @@ export function UserMiniCard({
   const pct = Math.min(100, Math.round((user.xp / user.xpToNext) * 100));
   return (
     <Link
-      href={`/${user.username}`}
+      href={`/@${user.username}`}
       className="block rounded-lg border bg-card text-card-foreground shadow-sm p-4"
     >
       <div className="text-sm font-semibold">{user.name}</div>

--- a/components/social/SocialActions.tsx
+++ b/components/social/SocialActions.tsx
@@ -58,7 +58,7 @@ export function SocialActions({
   const [messageText, setMessageText] = useState('');
   const [isNotificationsEnabled, setIsNotificationsEnabled] = useState(false);
 
-  const profileUrl = `${window.location.origin}/${username}`;
+  const profileUrl = `${window.location.origin}/@${username}`;
 
   const handleFollow = async () => {
     if (isFollowLoading) return;

--- a/components/user/FollowersModal.tsx
+++ b/components/user/FollowersModal.tsx
@@ -204,7 +204,7 @@ export function FollowersModal({ userId, type, isOpen, onClose }: FollowersModal
               
               return (
                 <div key={user.id} className="flex items-center gap-3 p-3 hover:bg-gray-50 rounded-lg transition-colors">
-                  <Avatar className="w-12 h-12 cursor-pointer" onClick={() => window.location.href = `/${user.username}`}> 
+                  <Avatar className="w-12 h-12 cursor-pointer" onClick={() => window.location.href = `/@${user.username}`}> 
                     <AvatarImage src={user.image} alt={user.name} />
                     <AvatarFallback>
                       {user.name?.charAt(0)?.toUpperCase()}
@@ -215,7 +215,7 @@ export function FollowersModal({ userId, type, isOpen, onClose }: FollowersModal
                     <div className="flex items-center gap-2">
                       <h3 
                         className="font-medium text-gray-900 truncate cursor-pointer hover:underline"
-                        onClick={() => window.location.href = `/${user.username}`}
+                        onClick={() => window.location.href = `/@${user.username}`}
                       >
                         {user.name}
                       </h3>


### PR DESCRIPTION
## Summary
- Link profile actions in navbars and sidebars to `/@usuario` instead of old paths
- Redirect profile pages and search results to the new username URL format
- Document navigation update in changelog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcd091e0f883218a60f440f4ba355c