### PR TITLE
Eliminar vista previa y habilitar edición de banner en el editor de perfil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Elimina la vista previa en el editor de perfil y permite modificar el banner desde la parte superior del modal.
 - Reconstruye el modal de edición de perfil con pestañas, vista previa en vivo y botón de cierre único.
 - Permite acceder a perfiles de usuario mediante rutas `/@usuario` y reemplaza prefijos `/u/`.
 - Actualiza menús y barras de navegación para enlazar a perfiles usando `/@usuario`.


### PR DESCRIPTION
## Resumen
- Quita la vista previa del modal de edición de perfil
- Permite cambiar el banner desde la parte superior del modal
- Documenta el cambio en el `CHANGELOG`

## Pruebas
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd4095b94832193e7b6d3a2539770