### PR TITLE
fix: evitar botones anidados en combobox y permitir limpiar con backspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Corrige botones anidados en `Combobox`, añade soporte para limpiar con Backspace y expone la nueva propiedad `onClear`.
+
 - Elimina la vista previa en el editor de perfil y permite modificar el banner desde la parte superior del modal.
 - Reconstruye el modal de edición de perfil con pestañas, vista previa en vivo y botón de cierre único.
 - Permite acceder a perfiles de usuario mediante rutas `/@usuario` y reemplaza prefijos `/u/`.

--- a/tests/combobox.test.tsx
+++ b/tests/combobox.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Combobox } from '@/components/ui/combobox';
+
+describe('Combobox clear functionality', () => {
+  const options = [
+    { value: '1', label: 'Uno' },
+    { value: '2', label: 'Dos' },
+  ];
+
+  test('calls onClear and onValueChange when clear button is clicked', () => {
+    const onValueChange = jest.fn();
+    const onClear = jest.fn();
+    render(
+      <Combobox
+        options={options}
+        value="1"
+        onValueChange={onValueChange}
+        clearable
+        onClear={onClear}
+        aria-label="Seleccionar opción"
+      />
+    );
+
+    const clearBtn = screen.getByRole('button', { name: 'Limpiar selección' });
+    fireEvent.click(clearBtn);
+
+    expect(onValueChange).toHaveBeenCalledWith('');
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  test('allows clearing with Backspace key', () => {
+    const onValueChange = jest.fn();
+    const onClear = jest.fn();
+    render(
+      <Combobox
+        options={options}
+        value="1"
+        onValueChange={onValueChange}
+        clearable
+        onClear={onClear}
+        aria-label="Seleccionar opción"
+      />
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Seleccionar opción' });
+    combobox.focus();
+    fireEvent.keyDown(combobox, { key: 'Backspace' });
+
+    expect(onValueChange).toHaveBeenCalledWith('');
+    expect(onClear).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- evita botones anidados en `Combobox` utilizando un elemento `span`
- añade la propiedad `onClear` y soporte para limpiar con la tecla Backspace
- agrega pruebas unitarias para limpiar mediante botón y teclado

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bce1b72b3483218d0fa3e2c6752320