### PR TITLE
fix: restrict combobox backspace clearing

### DIFF
--- a/components/ui/combobox.tsx
+++ b/components/ui/combobox.tsx
@@ -132,12 +132,17 @@ export function Combobox({
         case "Escape":
           setOpen(false);
           break;
-        case "Backspace":
+        case "Backspace": {
           if (clearable && selectedValues.length > 0) {
-            e.preventDefault();
-            handleClear();
+            const isInput =
+              (e.target as HTMLElement)?.tagName === "INPUT";
+            if (!isInput || searchValue === "") {
+              e.preventDefault();
+              handleClear();
+            }
           }
           break;
+        }
       }
     },
     [
@@ -148,6 +153,7 @@ export function Combobox({
       clearable,
       selectedValues,
       handleClear,
+      searchValue,
     ]
   );
 

--- a/tests/combobox.test.tsx
+++ b/tests/combobox.test.tsx
@@ -50,4 +50,29 @@ describe('Combobox clear functionality', () => {
     expect(onValueChange).toHaveBeenCalledWith('');
     expect(onClear).toHaveBeenCalled();
   });
+
+  test('does not clear when editing search input with Backspace', () => {
+    const onValueChange = jest.fn();
+    const onClear = jest.fn();
+    render(
+      <Combobox
+        options={options}
+        value="1"
+        onValueChange={onValueChange}
+        clearable
+        onClear={onClear}
+        aria-label="Seleccionar opción"
+      />
+    );
+
+    const combobox = screen.getByRole('combobox', { name: 'Seleccionar opción' });
+    fireEvent.click(combobox);
+
+    const input = screen.getByPlaceholderText('Buscar...');
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.keyDown(input, { key: 'Backspace' });
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(onClear).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- prevent Backspace from clearing selection while editing search input
- add test ensuring backspace on populated search field doesn't clear value

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bce35a84c48321892ca33b4c20991d