### PR TITLE
fix: handle missing pagination in feed hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - Corrige botones anidados en `Combobox`, añade soporte para limpiar con Backspace y expone la nueva propiedad `onClear`.
+- Maneja paginación faltante en hooks de feed para evitar errores de `hasMore`.
 
 - Elimina la vista previa en el editor de perfil y permite modificar el banner desde la parte superior del modal.
 - Reconstruye el modal de edición de perfil con pestañas, vista previa en vivo y botón de cierre único.

--- a/hooks/useFeed.ts
+++ b/hooks/useFeed.ts
@@ -67,7 +67,7 @@ export function useFeed(params: FeedParams = {}) {
       return response.json() as Promise<FeedResponse>;
     },
     getNextPageParam: (lastPage) => {
-      return lastPage.pagination.hasMore
+      return lastPage?.pagination?.hasMore
         ? lastPage.pagination.page + 1
         : undefined;
     },

--- a/hooks/useUnifiedFeed.ts
+++ b/hooks/useUnifiedFeed.ts
@@ -71,7 +71,7 @@ export function useUnifiedFeed(params: UnifiedFeedParams = {}) {
       return response.json()
     },
     getNextPageParam: (lastPage) => {
-      return lastPage.pagination.hasMore
+      return lastPage?.pagination?.hasMore
         ? lastPage.pagination.page + 1
         : undefined
     },


### PR DESCRIPTION
## Summary
- avoid `hasMore` crash when pagination is undefined in unified feed
- guard pagination in generic feed hook
- document fix in changelog

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error in app/api/content/[id]/interactions/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd15e5757c83218c1c66fe1d3827cb