### PR TITLE
fix: guard feed items without id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Corrige botones anidados en `Combobox`, añade soporte para limpiar con Backspace y expone la nueva propiedad `onClear`.
 - Maneja paginación faltante en hooks de feed para evitar errores de `hasMore`.
+- Evita errores de `id` indefinido en `UnifiedPostList` filtrando elementos inválidos.
 
 - Elimina la vista previa en el editor de perfil y permite modificar el banner desde la parte superior del modal.
 - Reconstruye el modal de edición de perfil con pestañas, vista previa en vivo y botón de cierre único.

--- a/components/feed/UnifiedPostList.tsx
+++ b/components/feed/UnifiedPostList.tsx
@@ -3,6 +3,7 @@
 import { Button } from '@/components/ui/button';
 import { LoaderIcon } from 'lucide-react';
 import { useUnifiedFeed } from '@/hooks/useUnifiedFeed';
+import type { UnifiedContentItem } from '@/hooks/useUnifiedFeed';
 import { UnifiedFeedCard } from './UnifiedFeedCard';
 
 export default function UnifiedPostList() {
@@ -38,7 +39,10 @@ export default function UnifiedPostList() {
     );
   }
 
-  const content = data?.pages.flatMap(page => page.content) || [];
+  // Filtra elementos inválidos para evitar errores al acceder a `id`
+  const content = (data?.pages.flatMap(page => page.content || []) || []).filter(
+    (item): item is UnifiedContentItem => Boolean(item?.id)
+  );
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- filter invalid feed items before rendering to avoid undefined `id`
- document feed fix in changelog

## Testing
- `npm test`
- `npm run lint` *(fails: Parsing error in app/api/content/[id]/interactions/route.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68bd29ced5b48321936aa7539cd78ea2